### PR TITLE
Update flatbuffer schema

### DIFF
--- a/docs/SSTable_format.md
+++ b/docs/SSTable_format.md
@@ -5,7 +5,8 @@ At a high level the SSTable consists of the following in this order:
 1. List of `Blocks` (where each Block contains KeyValue pairs)
 2. `BloomFilter` if the number of keys in SSTable is atleast DBOptions.MinFilterKeys
 3. `SsTableIndex` which contains the `Offset` and `FirstKey` of each Block added above
-4. `SsTableInfo` which is the meta information of the SSTable
+4. `SsTableInfo` which contains meta information of the SSTable like offset, length of `BloomFilter` and offset, length of `SsTableIndex`
+5. Finally the offset(4 bytes) of `SsTableInfo`
 
 
 ### KeyValue format

--- a/docs/SSTable_format.md
+++ b/docs/SSTable_format.md
@@ -96,23 +96,23 @@ The format is as follows
 ```
 type SsTableInfo struct {
     // contains the firstKey of the SSTable
-	FirstKey          []byte
-
+    FirstKey          []byte
+    
     // the offset at which SsTableIndex starts when SSTable is serialized.
-	// SsTableIndex holds the meta info about each block.
-	IndexOffset       uint64
-
+    // SsTableIndex holds the meta info about each block.
+    IndexOffset       uint64
+    
     // the length of the SSTableIndex.
-	IndexLen          uint64
-
+    IndexLen          uint64
+    
     // the offset at which BloomFilter starts when SSTable is serialized.
-	FilterOffset      uint64
-
+    FilterOffset      uint64
+    
     // the length of the BloomFilter
-	FilterLen         uint64
-
+    FilterLen         uint64
+    
     // the codec used to compress/decompress SSTable before serializing/desirializing
-	CompressionFormat CompressionFormat
+    CompressionFormat CompressionFormat
 }
 ```
 

--- a/docs/SSTable_format.md
+++ b/docs/SSTable_format.md
@@ -2,15 +2,15 @@
 ## SSTable
 
 At a high level the SSTable consists of the following in this order:
-1. List of Blocks (where each Block contains KeyValue pairs)
-2. BloomFilter if the number of keys in SSTable is atleast DBOptions.MinFilterKeys
-3. SsTableIndex which contains the `Offset` and `FirstKey` of each Block added above
-4. SsTableInfo which is the meta information of the SSTable
+1. List of `Blocks` (where each Block contains KeyValue pairs)
+2. `BloomFilter` if the number of keys in SSTable is atleast DBOptions.MinFilterKeys
+3. `SsTableIndex` which contains the `Offset` and `FirstKey` of each Block added above
+4. `SsTableInfo` which is the meta information of the SSTable
 
 
 ### KeyValue format
-If not a tombstone then KeyValue is represented as 
-
+```
+If not a tombstone then KeyValue is represented as
 ╭─────────┬────────────────┬────────────┬──────────────────╮
 │keyLength│ key            │ valueLength│ value            │
 ├─────────┼────────────────┼────────────┼──────────────────┤
@@ -18,19 +18,18 @@ If not a tombstone then KeyValue is represented as
 ╰─────────┴────────────────┴────────────┴──────────────────╯
 
 If it is a tombstone then KeyValue is represented as
-
 ╭─────────┬────────────────┬──────────╮
 │keyLength│ key            │ Tombstone│
 ├─────────┼────────────────┼──────────┤
 │2 bytes  │ keyLength bytes│ 4 bytes  │
 ╰─────────┴────────────────┴──────────╯
-
+```
 
 ### Block format
-Each Block contains the following: (Assume Block contains n KeyValue pairs and no compression)
-
+Each Block contains the following: (Assume Block contains 'n' KeyValue pairs)
+```
 ╭────────╮
-│KeyValue│ ... repeat 'n' KeyValue pairs in above [KeyValue format](#keyvalue-format)
+│KeyValue│ ... repeat 'n' KeyValue pairs in above KeyValue format.
 ╰────────╯
 
 Then we have offsets of each KeyValue pair
@@ -53,17 +52,17 @@ Then we have checksum of the above data combined
 ├────────┤
 │4 bytes │
 ╰────────╯
-
+```
 
 ### BloomFilter format 
-Assume no compression and number of keys added to BloomFilter is 'n'
-
+Assume number of keys added to BloomFilter is 'n'
+```
 ╭─────────────────────┬────────────────────╮
 │numberOfHashFunctions│ bitArray of filter │
 ├─────────────────────┼────────────────────┤
 │2 bytes              │ n * bitsPerKey bits│
 ╰─────────────────────┴────────────────────╯
-
+```
 
 ### SsTableIndex format
 SsTableIndex contains the `Offset` and `FirstKey` of each Block present in the SSTable. 
@@ -86,12 +85,13 @@ SsTableInfo contains the meta information of the SSTable
 This is serialized to bytes using flatbuffers
 
 The format is as follows
+```
 ╭──────────────────────┬─────────╮
 │serialized SsTableInfo│ checksum│
 ├──────────────────────┼─────────┤
 │                      │ 4 bytes │
 ╰──────────────────────┴─────────╯
-
+```
 
 ```
 type SsTableInfo struct {

--- a/docs/SSTable_format.md
+++ b/docs/SSTable_format.md
@@ -1,0 +1,120 @@
+
+## SSTable
+
+At a high level the SSTable consists of the following in this order:
+1. List of Blocks (where each Block contains KeyValue pairs)
+2. BloomFilter if the number of keys in SSTable is atleast DBOptions.MinFilterKeys
+3. SsTableIndex which contains the `Offset` and `FirstKey` of each Block added above
+4. SsTableInfo which is the meta information of the SSTable
+
+
+### KeyValue format
+If not a tombstone then KeyValue is represented as 
+
+╭─────────┬────────────────┬────────────┬──────────────────╮
+│keyLength│ key            │ valueLength│ value            │
+├─────────┼────────────────┼────────────┼──────────────────┤
+│2 bytes  │ keyLength bytes│ 4 bytes    │ valueLength bytes│
+╰─────────┴────────────────┴────────────┴──────────────────╯
+
+If it is a tombstone then KeyValue is represented as
+
+╭─────────┬────────────────┬──────────╮
+│keyLength│ key            │ Tombstone│
+├─────────┼────────────────┼──────────┤
+│2 bytes  │ keyLength bytes│ 4 bytes  │
+╰─────────┴────────────────┴──────────╯
+
+
+### Block format
+Each Block contains the following: (Assume Block contains n KeyValue pairs and no compression)
+
+╭────────╮
+│KeyValue│ ... repeat 'n' KeyValue pairs in above [KeyValue format](#keyvalue-format)
+╰────────╯
+
+Then we have offsets of each KeyValue pair
+╭───────╮
+│offset │
+├───────┤ ... repeat 'n' offsets
+│2 bytes│
+╰───────╯
+
+Then we have KeyValue pair count 'n'
+╭────────────────╮
+│KeyValue count n│
+├────────────────┤
+│2 bytes         │
+╰────────────────╯
+
+Then we have checksum of the above data combined
+╭────────╮
+│checksum│
+├────────┤
+│4 bytes │
+╰────────╯
+
+
+### BloomFilter format 
+Assume no compression and number of keys added to BloomFilter is 'n'
+
+╭─────────────────────┬────────────────────╮
+│numberOfHashFunctions│ bitArray of filter │
+├─────────────────────┼────────────────────┤
+│2 bytes              │ n * bitsPerKey bits│
+╰─────────────────────┴────────────────────╯
+
+
+### SsTableIndex format
+SsTableIndex contains the `Offset` and `FirstKey` of each Block present in the SSTable. 
+This is serialized to bytes using flatbuffers
+
+```
+type SsTableIndex struct {
+	BlockMeta []*BlockMeta
+}
+
+type BlockMeta struct {
+	Offset   uint64
+	FirstKey []byte
+}
+```
+
+
+### SsTableInfo format
+SsTableInfo contains the meta information of the SSTable
+This is serialized to bytes using flatbuffers
+
+The format is as follows
+╭──────────────────────┬─────────╮
+│serialized SsTableInfo│ checksum│
+├──────────────────────┼─────────┤
+│                      │ 4 bytes │
+╰──────────────────────┴─────────╯
+
+
+```
+type SsTableInfo struct {
+    // contains the firstKey of the SSTable
+	FirstKey          []byte
+
+    // the offset at which SsTableIndex starts when SSTable is serialized.
+	// SsTableIndex holds the meta info about each block.
+	IndexOffset       uint64
+
+    // the length of the SSTableIndex.
+	IndexLen          uint64
+
+    // the offset at which BloomFilter starts when SSTable is serialized.
+	FilterOffset      uint64
+
+    // the length of the BloomFilter
+	FilterLen         uint64
+
+    // the codec used to compress/decompress SSTable before serializing/desirializing
+	CompressionFormat CompressionFormat
+}
+```
+
+
+Note: Currently we are using compression for Block, BloomFIlter and SsTableIndex on the serialized data before writing to object storage if the user has initialized DB with DBOptions.CompressionCodec 

--- a/gen/manifest_generated.go
+++ b/gen/manifest_generated.go
@@ -4,7 +4,62 @@ package flatbuf
 
 import (
 	flatbuffers "github.com/google/flatbuffers/go"
+	"strconv"
 )
+
+type CompressionFormat int8
+
+const (
+	CompressionFormatNone   CompressionFormat = 0
+	CompressionFormatSnappy CompressionFormat = 1
+	CompressionFormatZlib   CompressionFormat = 2
+	CompressionFormatLz4    CompressionFormat = 3
+	CompressionFormatZstd   CompressionFormat = 4
+)
+
+var EnumNamesCompressionFormat = map[CompressionFormat]string{
+	CompressionFormatNone:   "None",
+	CompressionFormatSnappy: "Snappy",
+	CompressionFormatZlib:   "Zlib",
+	CompressionFormatLz4:    "Lz4",
+	CompressionFormatZstd:   "Zstd",
+}
+
+var EnumValuesCompressionFormat = map[string]CompressionFormat{
+	"None":   CompressionFormatNone,
+	"Snappy": CompressionFormatSnappy,
+	"Zlib":   CompressionFormatZlib,
+	"Lz4":    CompressionFormatLz4,
+	"Zstd":   CompressionFormatZstd,
+}
+
+func (v CompressionFormat) String() string {
+	if s, ok := EnumNamesCompressionFormat[v]; ok {
+		return s
+	}
+	return "CompressionFormat(" + strconv.FormatInt(int64(v), 10) + ")"
+}
+
+type SstRowAttribute int8
+
+const (
+	SstRowAttributeFlags SstRowAttribute = 0
+)
+
+var EnumNamesSstRowAttribute = map[SstRowAttribute]string{
+	SstRowAttributeFlags: "Flags",
+}
+
+var EnumValuesSstRowAttribute = map[string]SstRowAttribute{
+	"Flags": SstRowAttributeFlags,
+}
+
+func (v SstRowAttribute) String() string {
+	if s, ok := EnumNamesSstRowAttribute[v]; ok {
+		return s
+	}
+	return "SstRowAttribute(" + strconv.FormatInt(int64(v), 10) + ")"
+}
 
 type CompactedSstIdT struct {
 	High uint64 `json:"high"`
@@ -213,10 +268,13 @@ func CompactedSsTableEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 }
 
 type SsTableInfoT struct {
-	FirstKey     []byte        `json:"first_key"`
-	BlockMeta    []*BlockMetaT `json:"block_meta"`
-	FilterOffset uint64        `json:"filter_offset"`
-	FilterLen    uint64        `json:"filter_len"`
+	FirstKey          []byte            `json:"first_key"`
+	IndexOffset       uint64            `json:"index_offset"`
+	IndexLen          uint64            `json:"index_len"`
+	FilterOffset      uint64            `json:"filter_offset"`
+	FilterLen         uint64            `json:"filter_len"`
+	CompressionFormat CompressionFormat `json:"compression_format"`
+	RowAttributes     []SstRowAttribute `json:"row_attributes"`
 }
 
 func (t *SsTableInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
@@ -227,38 +285,38 @@ func (t *SsTableInfoT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t.FirstKey != nil {
 		firstKeyOffset = builder.CreateByteString(t.FirstKey)
 	}
-	blockMetaOffset := flatbuffers.UOffsetT(0)
-	if t.BlockMeta != nil {
-		blockMetaLength := len(t.BlockMeta)
-		blockMetaOffsets := make([]flatbuffers.UOffsetT, blockMetaLength)
-		for j := 0; j < blockMetaLength; j++ {
-			blockMetaOffsets[j] = t.BlockMeta[j].Pack(builder)
+	rowAttributesOffset := flatbuffers.UOffsetT(0)
+	if t.RowAttributes != nil {
+		rowAttributesLength := len(t.RowAttributes)
+		SsTableInfoStartRowAttributesVector(builder, rowAttributesLength)
+		for j := rowAttributesLength - 1; j >= 0; j-- {
+			builder.PrependInt8(int8(t.RowAttributes[j]))
 		}
-		SsTableInfoStartBlockMetaVector(builder, blockMetaLength)
-		for j := blockMetaLength - 1; j >= 0; j-- {
-			builder.PrependUOffsetT(blockMetaOffsets[j])
-		}
-		blockMetaOffset = builder.EndVector(blockMetaLength)
+		rowAttributesOffset = builder.EndVector(rowAttributesLength)
 	}
 	SsTableInfoStart(builder)
 	SsTableInfoAddFirstKey(builder, firstKeyOffset)
-	SsTableInfoAddBlockMeta(builder, blockMetaOffset)
+	SsTableInfoAddIndexOffset(builder, t.IndexOffset)
+	SsTableInfoAddIndexLen(builder, t.IndexLen)
 	SsTableInfoAddFilterOffset(builder, t.FilterOffset)
 	SsTableInfoAddFilterLen(builder, t.FilterLen)
+	SsTableInfoAddCompressionFormat(builder, t.CompressionFormat)
+	SsTableInfoAddRowAttributes(builder, rowAttributesOffset)
 	return SsTableInfoEnd(builder)
 }
 
 func (rcv *SsTableInfo) UnPackTo(t *SsTableInfoT) {
 	t.FirstKey = rcv.FirstKeyBytes()
-	blockMetaLength := rcv.BlockMetaLength()
-	t.BlockMeta = make([]*BlockMetaT, blockMetaLength)
-	for j := 0; j < blockMetaLength; j++ {
-		x := BlockMeta{}
-		rcv.BlockMeta(&x, j)
-		t.BlockMeta[j] = x.UnPack()
-	}
+	t.IndexOffset = rcv.IndexOffset()
+	t.IndexLen = rcv.IndexLen()
 	t.FilterOffset = rcv.FilterOffset()
 	t.FilterLen = rcv.FilterLen()
+	t.CompressionFormat = rcv.CompressionFormat()
+	rowAttributesLength := rcv.RowAttributesLength()
+	t.RowAttributes = make([]SstRowAttribute, rowAttributesLength)
+	for j := 0; j < rowAttributesLength; j++ {
+		t.RowAttributes[j] = rcv.RowAttributes(j)
+	}
 }
 
 func (rcv *SsTableInfo) UnPack() *SsTableInfoT {
@@ -339,27 +397,19 @@ func (rcv *SsTableInfo) MutateFirstKey(j int, n byte) bool {
 	return false
 }
 
-func (rcv *SsTableInfo) BlockMeta(obj *BlockMeta, j int) bool {
+func (rcv *SsTableInfo) IndexOffset() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
-		x := rcv._tab.Vector(o)
-		x += flatbuffers.UOffsetT(j) * 4
-		x = rcv._tab.Indirect(x)
-		obj.Init(rcv._tab.Bytes, x)
-		return true
-	}
-	return false
-}
-
-func (rcv *SsTableInfo) BlockMetaLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
-	if o != 0 {
-		return rcv._tab.VectorLen(o)
+		return rcv._tab.GetUint64(o + rcv._tab.Pos)
 	}
 	return 0
 }
 
-func (rcv *SsTableInfo) FilterOffset() uint64 {
+func (rcv *SsTableInfo) MutateIndexOffset(n uint64) bool {
+	return rcv._tab.MutateUint64Slot(6, n)
+}
+
+func (rcv *SsTableInfo) IndexLen() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return rcv._tab.GetUint64(o + rcv._tab.Pos)
@@ -367,11 +417,11 @@ func (rcv *SsTableInfo) FilterOffset() uint64 {
 	return 0
 }
 
-func (rcv *SsTableInfo) MutateFilterOffset(n uint64) bool {
+func (rcv *SsTableInfo) MutateIndexLen(n uint64) bool {
 	return rcv._tab.MutateUint64Slot(8, n)
 }
 
-func (rcv *SsTableInfo) FilterLen() uint64 {
+func (rcv *SsTableInfo) FilterOffset() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.GetUint64(o + rcv._tab.Pos)
@@ -379,12 +429,62 @@ func (rcv *SsTableInfo) FilterLen() uint64 {
 	return 0
 }
 
-func (rcv *SsTableInfo) MutateFilterLen(n uint64) bool {
+func (rcv *SsTableInfo) MutateFilterOffset(n uint64) bool {
 	return rcv._tab.MutateUint64Slot(10, n)
 }
 
+func (rcv *SsTableInfo) FilterLen() uint64 {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
+	if o != 0 {
+		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *SsTableInfo) MutateFilterLen(n uint64) bool {
+	return rcv._tab.MutateUint64Slot(12, n)
+}
+
+func (rcv *SsTableInfo) CompressionFormat() CompressionFormat {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
+	if o != 0 {
+		return CompressionFormat(rcv._tab.GetInt8(o + rcv._tab.Pos))
+	}
+	return 0
+}
+
+func (rcv *SsTableInfo) MutateCompressionFormat(n CompressionFormat) bool {
+	return rcv._tab.MutateInt8Slot(14, int8(n))
+}
+
+func (rcv *SsTableInfo) RowAttributes(j int) SstRowAttribute {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return SstRowAttribute(rcv._tab.GetInt8(a + flatbuffers.UOffsetT(j*1)))
+	}
+	return 0
+}
+
+func (rcv *SsTableInfo) RowAttributesLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
+	}
+	return 0
+}
+
+func (rcv *SsTableInfo) MutateRowAttributes(j int, n SstRowAttribute) bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return rcv._tab.MutateInt8(a+flatbuffers.UOffsetT(j*1), int8(n))
+	}
+	return false
+}
+
 func SsTableInfoStart(builder *flatbuffers.Builder) {
-	builder.StartObject(4)
+	builder.StartObject(7)
 }
 func SsTableInfoAddFirstKey(builder *flatbuffers.Builder, firstKey flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(firstKey), 0)
@@ -392,17 +492,26 @@ func SsTableInfoAddFirstKey(builder *flatbuffers.Builder, firstKey flatbuffers.U
 func SsTableInfoStartFirstKeyVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(1, numElems, 1)
 }
-func SsTableInfoAddBlockMeta(builder *flatbuffers.Builder, blockMeta flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(blockMeta), 0)
+func SsTableInfoAddIndexOffset(builder *flatbuffers.Builder, indexOffset uint64) {
+	builder.PrependUint64Slot(1, indexOffset, 0)
 }
-func SsTableInfoStartBlockMetaVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
-	return builder.StartVector(4, numElems, 4)
+func SsTableInfoAddIndexLen(builder *flatbuffers.Builder, indexLen uint64) {
+	builder.PrependUint64Slot(2, indexLen, 0)
 }
 func SsTableInfoAddFilterOffset(builder *flatbuffers.Builder, filterOffset uint64) {
-	builder.PrependUint64Slot(2, filterOffset, 0)
+	builder.PrependUint64Slot(3, filterOffset, 0)
 }
 func SsTableInfoAddFilterLen(builder *flatbuffers.Builder, filterLen uint64) {
-	builder.PrependUint64Slot(3, filterLen, 0)
+	builder.PrependUint64Slot(4, filterLen, 0)
+}
+func SsTableInfoAddCompressionFormat(builder *flatbuffers.Builder, compressionFormat CompressionFormat) {
+	builder.PrependInt8Slot(5, int8(compressionFormat), 0)
+}
+func SsTableInfoAddRowAttributes(builder *flatbuffers.Builder, rowAttributes flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(6, flatbuffers.UOffsetT(rowAttributes), 0)
+}
+func SsTableInfoStartRowAttributesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(1, numElems, 1)
 }
 func SsTableInfoEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
@@ -535,6 +644,119 @@ func BlockMetaStartFirstKeyVector(builder *flatbuffers.Builder, numElems int) fl
 	return builder.StartVector(1, numElems, 1)
 }
 func BlockMetaEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	return builder.EndObject()
+}
+
+type SsTableIndexT struct {
+	BlockMeta []*BlockMetaT `json:"block_meta"`
+}
+
+func (t *SsTableIndexT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	if t == nil {
+		return 0
+	}
+	blockMetaOffset := flatbuffers.UOffsetT(0)
+	if t.BlockMeta != nil {
+		blockMetaLength := len(t.BlockMeta)
+		blockMetaOffsets := make([]flatbuffers.UOffsetT, blockMetaLength)
+		for j := 0; j < blockMetaLength; j++ {
+			blockMetaOffsets[j] = t.BlockMeta[j].Pack(builder)
+		}
+		SsTableIndexStartBlockMetaVector(builder, blockMetaLength)
+		for j := blockMetaLength - 1; j >= 0; j-- {
+			builder.PrependUOffsetT(blockMetaOffsets[j])
+		}
+		blockMetaOffset = builder.EndVector(blockMetaLength)
+	}
+	SsTableIndexStart(builder)
+	SsTableIndexAddBlockMeta(builder, blockMetaOffset)
+	return SsTableIndexEnd(builder)
+}
+
+func (rcv *SsTableIndex) UnPackTo(t *SsTableIndexT) {
+	blockMetaLength := rcv.BlockMetaLength()
+	t.BlockMeta = make([]*BlockMetaT, blockMetaLength)
+	for j := 0; j < blockMetaLength; j++ {
+		x := BlockMeta{}
+		rcv.BlockMeta(&x, j)
+		t.BlockMeta[j] = x.UnPack()
+	}
+}
+
+func (rcv *SsTableIndex) UnPack() *SsTableIndexT {
+	if rcv == nil {
+		return nil
+	}
+	t := &SsTableIndexT{}
+	rcv.UnPackTo(t)
+	return t
+}
+
+type SsTableIndex struct {
+	_tab flatbuffers.Table
+}
+
+func GetRootAsSsTableIndex(buf []byte, offset flatbuffers.UOffsetT) *SsTableIndex {
+	n := flatbuffers.GetUOffsetT(buf[offset:])
+	x := &SsTableIndex{}
+	x.Init(buf, n+offset)
+	return x
+}
+
+func FinishSsTableIndexBuffer(builder *flatbuffers.Builder, offset flatbuffers.UOffsetT) {
+	builder.Finish(offset)
+}
+
+func GetSizePrefixedRootAsSsTableIndex(buf []byte, offset flatbuffers.UOffsetT) *SsTableIndex {
+	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
+	x := &SsTableIndex{}
+	x.Init(buf, n+offset+flatbuffers.SizeUint32)
+	return x
+}
+
+func FinishSizePrefixedSsTableIndexBuffer(builder *flatbuffers.Builder, offset flatbuffers.UOffsetT) {
+	builder.FinishSizePrefixed(offset)
+}
+
+func (rcv *SsTableIndex) Init(buf []byte, i flatbuffers.UOffsetT) {
+	rcv._tab.Bytes = buf
+	rcv._tab.Pos = i
+}
+
+func (rcv *SsTableIndex) Table() flatbuffers.Table {
+	return rcv._tab
+}
+
+func (rcv *SsTableIndex) BlockMeta(obj *BlockMeta, j int) bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
+	if o != 0 {
+		x := rcv._tab.Vector(o)
+		x += flatbuffers.UOffsetT(j) * 4
+		x = rcv._tab.Indirect(x)
+		obj.Init(rcv._tab.Bytes, x)
+		return true
+	}
+	return false
+}
+
+func (rcv *SsTableIndex) BlockMetaLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
+	}
+	return 0
+}
+
+func SsTableIndexStart(builder *flatbuffers.Builder) {
+	builder.StartObject(1)
+}
+func SsTableIndexAddBlockMeta(builder *flatbuffers.Builder, blockMeta flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(blockMeta), 0)
+}
+func SsTableIndexStartBlockMetaVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(4, numElems, 4)
+}
+func SsTableIndexEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 

--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -16,8 +16,9 @@ enum CompressionFormat: byte {
     Zstd
 }
 
-enum SstRowAttribute: byte {
-    Flags
+enum SstRowFeature: byte {
+    Flags,
+    Timestamp
 }
 
 // Has metadata about a SST file.
@@ -40,8 +41,8 @@ table SsTableInfo {
     // Type of compression algorithm used.
     compression_format: CompressionFormat;
 
-    // The row level attributes enabled for this SST
-    row_attributes: [SstRowAttribute];
+    // The row level features enabled for this SST
+    row_features: [SstRowFeature];
 }
 
 table BlockMeta {

--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -16,11 +16,6 @@ enum CompressionFormat: byte {
     Zstd
 }
 
-enum SstRowFeature: byte {
-    Flags,
-    Timestamp
-}
-
 // Has metadata about a SST file.
 table SsTableInfo {
     // First key in the SST file.
@@ -40,9 +35,6 @@ table SsTableInfo {
 
     // Type of compression algorithm used.
     compression_format: CompressionFormat;
-
-    // The row level features enabled for this SST
-    row_features: [SstRowFeature];
 }
 
 table BlockMeta {

--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -4,8 +4,20 @@ table CompactedSstId {
 }
 
 table CompactedSsTable {
-    id: CompactedSstId;
-    info: SsTableInfo;
+    id: CompactedSstId (required);
+    info: SsTableInfo (required);
+}
+
+enum CompressionFormat: byte {
+    None,
+    Snappy,
+    Zlib,
+    Lz4,
+    Zstd
+}
+
+enum SstRowAttribute: byte {
+    Flags
 }
 
 // Has metadata about a SST file.
@@ -13,16 +25,23 @@ table SsTableInfo {
     // First key in the SST file.
     first_key: [ubyte];
 
-    // TODO: we should move this index out into its own object
-    //       https://github.com/slatedb/slatedb/issues/88
-    // Sequence of block metadata. SST files could have multiple blocks.
-    block_meta: [BlockMeta] (required);
+    // Offset of the index block.
+    index_offset: ulong;
+
+    // Length of the index block.
+    index_len: ulong;
 
     // Offset of the bloom filter.
     filter_offset: ulong;
 
     // Length of bloom filter. Length will be zero if filter is not present.
     filter_len: ulong;
+
+    // Type of compression algorithm used.
+    compression_format: CompressionFormat;
+
+    // The row level attributes enabled for this SST
+    row_attributes: [SstRowAttribute];
 }
 
 table BlockMeta {
@@ -31,4 +50,8 @@ table BlockMeta {
 
     // First key contained in the block.
     first_key: [ubyte] (required);
+}
+
+table SsTableIndex {
+    block_meta: [BlockMeta] (required);
 }

--- a/slatedb/block.go
+++ b/slatedb/block.go
@@ -66,16 +66,20 @@ func decodeBytesToBlock(bytes []byte) *Block {
 // ------------------------------------------------
 
 type BlockBuilder struct {
-	offsets   []uint16
-	data      []byte
-	blockSize uint64
+	offsets     []uint16
+	data        []byte
+	blockSize   uint64
+	firstKey    []byte
+	rowFeatures []RowFeature
 }
 
-func newBlockBuilder(blockSize uint64) *BlockBuilder {
+func newBlockBuilder(blockSize uint64, rowFeatures []RowFeature) *BlockBuilder {
 	return &BlockBuilder{
-		offsets:   make([]uint16, 0),
-		data:      make([]byte, 0),
-		blockSize: blockSize,
+		offsets:     make([]uint16, 0),
+		data:        make([]byte, 0),
+		blockSize:   blockSize,
+		firstKey:    make([]byte, 0),
+		rowFeatures: rowFeatures,
 	}
 }
 

--- a/slatedb/block.go
+++ b/slatedb/block.go
@@ -66,20 +66,18 @@ func decodeBytesToBlock(bytes []byte) *Block {
 // ------------------------------------------------
 
 type BlockBuilder struct {
-	offsets     []uint16
-	data        []byte
-	blockSize   uint64
-	firstKey    []byte
-	rowFeatures []RowFeature
+	offsets   []uint16
+	data      []byte
+	blockSize uint64
+	firstKey  []byte
 }
 
-func newBlockBuilder(blockSize uint64, rowFeatures []RowFeature) *BlockBuilder {
+func newBlockBuilder(blockSize uint64) *BlockBuilder {
 	return &BlockBuilder{
-		offsets:     make([]uint16, 0),
-		data:        make([]byte, 0),
-		blockSize:   blockSize,
-		firstKey:    make([]byte, 0),
-		rowFeatures: rowFeatures,
+		offsets:   make([]uint16, 0),
+		data:      make([]byte, 0),
+		blockSize: blockSize,
+		firstKey:  make([]byte, 0),
 	}
 }
 

--- a/slatedb/block.go
+++ b/slatedb/block.go
@@ -69,7 +69,6 @@ type BlockBuilder struct {
 	offsets   []uint16
 	data      []byte
 	blockSize uint64
-	firstKey  []byte
 }
 
 func newBlockBuilder(blockSize uint64) *BlockBuilder {
@@ -77,7 +76,6 @@ func newBlockBuilder(blockSize uint64) *BlockBuilder {
 		offsets:   make([]uint16, 0),
 		data:      make([]byte, 0),
 		blockSize: blockSize,
-		firstKey:  make([]byte, 0),
 	}
 }
 
@@ -138,6 +136,7 @@ func (b *BlockBuilder) build() (*Block, error) {
 // BlockIterator
 // ------------------------------------------------
 
+// BlockIterator helps in iterating through KeyValue pairs present in the Block.
 type BlockIterator struct {
 	block       *Block
 	offsetIndex uint64

--- a/slatedb/compactor.go
+++ b/slatedb/compactor.go
@@ -358,14 +358,22 @@ func (e *CompactionExecutor) loadIterators(compaction CompactionJob) (iter.KVIte
 
 	l0Iters := make([]iter.KVIterator, 0)
 	for _, sst := range compaction.sstList {
-		sstIter := newSSTIterator(&sst, e.tableStore.clone(), 4, 256)
+		sstIter, err := newSSTIterator(&sst, e.tableStore.clone(), 4, 256)
+		if err != nil {
+			return nil, err
+		}
+
 		sstIter.spawnFetches()
 		l0Iters = append(l0Iters, sstIter)
 	}
 
 	srIters := make([]iter.KVIterator, 0)
 	for _, sr := range compaction.sortedRuns {
-		srIter := newSortedRunIterator(sr, e.tableStore.clone(), 16, 256)
+		srIter, err := newSortedRunIterator(sr, e.tableStore.clone(), 16, 256)
+		if err != nil {
+			return nil, err
+		}
+
 		if srIter.currentKVIter.IsPresent() {
 			sstIter, _ := srIter.currentKVIter.Get()
 			sstIter.spawnFetches()

--- a/slatedb/compactor.go
+++ b/slatedb/compactor.go
@@ -291,7 +291,7 @@ func (o *CompactorOrchestrator) writeManifest() error {
 		core := o.state.dbState.clone()
 		err = o.manifest.updateDBState(core)
 		if errors.Is(err, common.ErrManifestVersionExists) {
-			logger.Error("conflicting manifest version. retry write", zap.Error(err))
+			logger.Warn("conflicting manifest version. retry write", zap.Error(err))
 			continue
 		}
 		return err
@@ -301,7 +301,7 @@ func (o *CompactorOrchestrator) writeManifest() error {
 func (o *CompactorOrchestrator) submitCompaction(compaction Compaction) error {
 	err := o.state.submitCompaction(compaction)
 	if err != nil {
-		logger.Error("invalid compaction", zap.Error(err))
+		logger.Warn("invalid compaction", zap.Error(err))
 		return nil
 	}
 	o.startCompaction(compaction)

--- a/slatedb/compactor_test.go
+++ b/slatedb/compactor_test.go
@@ -46,7 +46,8 @@ func TestCompactorCompactsL0(t *testing.T) {
 	assert.Equal(t, 1, len(compactedSSTList))
 
 	sst := compactedSSTList[0]
-	iter := newSSTIterator(&sst, tableStore, 1, 1)
+	iter, err := newSSTIterator(&sst, tableStore, 1, 1)
+	assert.NoError(t, err)
 	for i := 0; i < 4; i++ {
 		next, err := iter.Next()
 		assert.NoError(t, err)
@@ -128,7 +129,10 @@ func buildTestDB(options DBOptions) (objstore.Bucket, *ManifestStore, *TableStor
 	bucket := objstore.NewInMemBucket()
 	db, err := OpenWithOptions(testPath, bucket, options)
 	common.AssertTrue(err == nil, "Failed to open test database")
-	sstFormat := newSSTableFormat(32, 10, options.CompressionCodec)
+	sstFormat := defaultSSTableFormat()
+	sstFormat.blockSize = 32
+	sstFormat.minFilterKeys = 10
+	sstFormat.compressionCodec = options.CompressionCodec
 	manifestStore := newManifestStore(testPath, bucket)
 	tableStore := newTableStore(bucket, sstFormat, testPath)
 	return bucket, manifestStore, tableStore, db

--- a/slatedb/config.go
+++ b/slatedb/config.go
@@ -2,10 +2,10 @@ package slatedb
 
 import "time"
 
-type CompressionCodec int
+type CompressionCodec int8
 
 const (
-	CompressionNone CompressionCodec = iota + 1
+	CompressionNone CompressionCodec = iota
 	CompressionSnappy
 	CompressionZlib
 	CompressionLz4

--- a/slatedb/db_state.go
+++ b/slatedb/db_state.go
@@ -283,3 +283,25 @@ func (h *SSTableHandle) clone() *SSTableHandle {
 		info: h.info.clone(),
 	}
 }
+
+type RowFeature int8
+
+const (
+	Flags RowFeature = iota + 1
+	Timestamp
+)
+
+type SSTableInfo struct {
+	firstKey         mo.Option[[]byte]
+	indexOffset      uint64
+	indexLen         uint64
+	filterOffset     uint64
+	filterLen        uint64
+	compressionCodec CompressionCodec
+	rowFeatures      []RowFeature
+}
+
+type SsTableInfoCodec interface {
+	encode(manifest SSTableInfo) []byte
+	decode(data []byte) (SSTableInfo, error)
+}

--- a/slatedb/db_state.go
+++ b/slatedb/db_state.go
@@ -287,7 +287,7 @@ func (h *SSTableHandle) clone() *SSTableHandle {
 type RowFeature int8
 
 const (
-	Flags RowFeature = iota + 1
+	Flags RowFeature = iota
 	Timestamp
 )
 

--- a/slatedb/db_state.go
+++ b/slatedb/db_state.go
@@ -288,7 +288,8 @@ func (h *SSTableHandle) clone() *SSTableHandle {
 	}
 }
 
-// SSTableInfo contains information on the SSTable when it is serialized.
+// SSTableInfo contains meta information on the SSTable when it is serialized.
+// This is used when we read SSTable as a slice of bytes from object storage and we want to parse the slice of bytes
 // Each SSTable is a list of blocks and each block is a list of KeyValue pairs.
 type SSTableInfo struct {
 	// contains the firstKey of the SSTable

--- a/slatedb/db_state.go
+++ b/slatedb/db_state.go
@@ -263,6 +263,7 @@ func (s *SSTableID) clone() SSTableID {
 // SSTableHandle
 // ------------------------------------------------
 
+// SSTableHandle represents the SSTable
 type SSTableHandle struct {
 	id   SSTableID
 	info *SSTableInfo
@@ -287,12 +288,26 @@ func (h *SSTableHandle) clone() *SSTableHandle {
 	}
 }
 
+// SSTableInfo contains information on the SSTable when it is serialized.
+// Each SSTable is a list of blocks and each block is a list of KeyValue pairs.
 type SSTableInfo struct {
-	firstKey         mo.Option[[]byte]
-	indexOffset      uint64
-	indexLen         uint64
-	filterOffset     uint64
-	filterLen        uint64
+	// contains the firstKey of the SSTable
+	firstKey mo.Option[[]byte]
+
+	// the offset at which SSTableIndex starts when SSTable is serialized.
+	// SSTableIndex holds the meta info about each block. SSTableIndex is defined in schemas/sst.fbs
+	indexOffset uint64
+
+	// the length of the SSTableIndex.
+	indexLen uint64
+
+	// the offset at which Bloom filter starts when SSTable is serialized.
+	filterOffset uint64
+
+	// the length of the Bloom filter
+	filterLen uint64
+
+	// the codec used to compress/decompress SSTable before writing/reading from object storage
 	compressionCodec CompressionCodec
 }
 
@@ -314,6 +329,9 @@ func (info *SSTableInfo) clone() *SSTableInfo {
 	}
 }
 
+// SsTableInfoCodec - implementation of this interface defines how we
+// encode SSTableInfo to byte slice and decode byte slice back to SSTableInfo
+// Currently we use FlatBuffers for encoding and decoding.
 type SsTableInfoCodec interface {
 	encode(info *SSTableInfo) []byte
 	decode(data []byte) *SSTableInfo

--- a/slatedb/db_state_test.go
+++ b/slatedb/db_state_test.go
@@ -1,25 +1,21 @@
 package slatedb
 
 import (
-	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/mo"
-	flatbuf "github.com/slatedb/slatedb-go/gen"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func addL0sToDBState(dbState *DBState, n uint32) {
-	builder := flatbuffers.NewBuilder(0)
-	ssTableInfoT := flatbuf.SsTableInfoT{
-		FirstKey:     nil,
-		BlockMeta:    []*flatbuf.BlockMetaT{},
-		FilterOffset: 0,
-		FilterLen:    uint64(0),
+	sstInfo := &SSTableInfo{
+		firstKey:         mo.None[[]byte](),
+		indexOffset:      0,
+		indexLen:         0,
+		filterOffset:     0,
+		filterLen:        0,
+		compressionCodec: CompressionNone,
 	}
-	infoOffset := ssTableInfoT.Pack(builder)
-	builder.Finish(infoOffset)
-	sstInfo := newSSTableInfo(builder.FinishedBytes())
 
 	for i := 0; i < int(n); i++ {
 		dbState.freezeMemtable(uint64(i))

--- a/slatedb/db_state_test.go
+++ b/slatedb/db_state_test.go
@@ -19,7 +19,7 @@ func addL0sToDBState(dbState *DBState, n uint32) {
 	}
 	infoOffset := ssTableInfoT.Pack(builder)
 	builder.Finish(infoOffset)
-	sstInfo := newSSTableInfoOwned(builder.FinishedBytes())
+	sstInfo := newSSTableInfo(builder.FinishedBytes())
 
 	for i := 0; i < int(n); i++ {
 		dbState.freezeMemtable(uint64(i))

--- a/slatedb/db_test.go
+++ b/slatedb/db_test.go
@@ -56,7 +56,8 @@ func TestPutFlushesMemtable(t *testing.T) {
 	assert.True(t, stored.IsPresent())
 
 	storedManifest, _ := stored.Get()
-	sstFormat := newSSTableFormat(4096, 10, CompressionNone)
+	sstFormat := defaultSSTableFormat()
+	sstFormat.minFilterKeys = 10
 	tableStore := newTableStore(bucket, sstFormat, dbPath)
 
 	lastCompacted := uint64(0)
@@ -82,7 +83,8 @@ func TestPutFlushesMemtable(t *testing.T) {
 	assert.Equal(t, 3, len(l0))
 	for i := 0; i < 3; i++ {
 		sst := l0[2-i]
-		iter := newSSTIterator(&sst, tableStore, 1, 1)
+		iter, err := newSSTIterator(&sst, tableStore, 1, 1)
+		assert.NoError(t, err)
 
 		kvOption, err := iter.Next()
 		assert.NoError(t, err)

--- a/slatedb/flatbuf_types.go
+++ b/slatedb/flatbuf_types.go
@@ -171,3 +171,51 @@ func (fb DBFlatBufferBuilder) addSortedRun(sortedRun SortedRun) *flatbuf.SortedR
 		Ssts: fb.addCompactedSSTs(sortedRun.sstList),
 	}
 }
+
+// ------------------------------------------------
+// SSTableInfoOwned
+// ------------------------------------------------
+
+type SSTableInfoOwned struct {
+	data []byte
+}
+
+func newSSTableInfoOwned(data []byte) *SSTableInfoOwned {
+	return &SSTableInfoOwned{data: data}
+}
+
+func (info *SSTableInfoOwned) borrow() *flatbuf.SsTableInfo {
+	return flatbuf.GetRootAsSsTableInfo(info.data, 0)
+}
+
+func (info *SSTableInfoOwned) clone() *SSTableInfoOwned {
+	data := make([]byte, len(info.data))
+	copy(data, info.data)
+	return &SSTableInfoOwned{
+		data: data,
+	}
+}
+
+// ------------------------------------------------
+// SSTableIndexOwned
+// ------------------------------------------------
+
+type SSTableIndexOwned struct {
+	data []byte
+}
+
+func newSSTableIndexOwned(data []byte) *SSTableIndexOwned {
+	return &SSTableIndexOwned{data: data}
+}
+
+func (info *SSTableIndexOwned) borrow() *flatbuf.SsTableIndex {
+	return flatbuf.GetRootAsSsTableIndex(info.data, 0)
+}
+
+func (info *SSTableIndexOwned) clone() *SSTableIndexOwned {
+	data := make([]byte, len(info.data))
+	copy(data, info.data)
+	return &SSTableIndexOwned{
+		data: data,
+	}
+}

--- a/slatedb/flatbuf_types.go
+++ b/slatedb/flatbuf_types.go
@@ -124,10 +124,6 @@ func (f FlatBufferManifestCodec) parseFlatBufSSTInfo(info *flatbuf.SsTableInfoT)
 	if keyBytes != nil {
 		firstKey = mo.Some(keyBytes)
 	}
-	rowFeatures := make([]RowFeature, 0)
-	for _, rowFeature := range info.RowFeatures {
-		rowFeatures = append(rowFeatures, RowFeature(rowFeature))
-	}
 	return &SSTableInfo{
 		firstKey:         firstKey,
 		indexOffset:      info.IndexOffset,
@@ -135,7 +131,6 @@ func (f FlatBufferManifestCodec) parseFlatBufSSTInfo(info *flatbuf.SsTableInfoT)
 		filterOffset:     info.FilterOffset,
 		filterLen:        info.FilterLen,
 		compressionCodec: compressionCodecFromFlatBuf(info.CompressionFormat),
-		rowFeatures:      rowFeatures,
 	}
 }
 
@@ -243,11 +238,6 @@ func sstInfoFromFlatBuf(info *flatbuf.SsTableInfo) *SSTableInfo {
 		firstKey = mo.Some(keyBytes)
 	}
 
-	rowFeatures := make([]RowFeature, 0)
-	for i := 0; i < info.RowFeaturesLength(); i++ {
-		rowFeatures = append(rowFeatures, rowFeatureFromFlatBuf(info.RowFeatures(i)))
-	}
-
 	return &SSTableInfo{
 		firstKey:         firstKey,
 		indexOffset:      info.IndexOffset(),
@@ -255,7 +245,6 @@ func sstInfoFromFlatBuf(info *flatbuf.SsTableInfo) *SSTableInfo {
 		filterOffset:     info.FilterOffset(),
 		filterLen:        info.FilterLen(),
 		compressionCodec: compressionCodecFromFlatBuf(info.CompressionFormat()),
-		rowFeatures:      rowFeatures,
 	}
 }
 
@@ -265,11 +254,6 @@ func sstInfoToFlatBuf(info *SSTableInfo) *flatbuf.SsTableInfoT {
 		firstKey, _ = info.firstKey.Get()
 	}
 
-	rowFeatures := make([]flatbuf.SstRowFeature, 0)
-	for _, rowFeature := range info.rowFeatures {
-		rowFeatures = append(rowFeatures, rowFeatureToFlatBuf(rowFeature))
-	}
-
 	return &flatbuf.SsTableInfoT{
 		FirstKey:          firstKey,
 		IndexOffset:       info.indexOffset,
@@ -277,29 +261,6 @@ func sstInfoToFlatBuf(info *SSTableInfo) *flatbuf.SsTableInfoT {
 		FilterOffset:      info.filterOffset,
 		FilterLen:         info.filterLen,
 		CompressionFormat: compressionCodecToFlatBuf(info.compressionCodec),
-		RowFeatures:       rowFeatures,
-	}
-}
-
-func rowFeatureFromFlatBuf(sstRowFeature flatbuf.SstRowFeature) RowFeature {
-	switch sstRowFeature {
-	case flatbuf.SstRowFeatureFlags:
-		return RowFeatureFlags
-	case flatbuf.SstRowFeatureTimestamp:
-		return RowFeatureTimestamp
-	default:
-		panic("invalid RowFeature")
-	}
-}
-
-func rowFeatureToFlatBuf(rowFeature RowFeature) flatbuf.SstRowFeature {
-	switch rowFeature {
-	case RowFeatureFlags:
-		return flatbuf.SstRowFeatureFlags
-	case RowFeatureTimestamp:
-		return flatbuf.SstRowFeatureTimestamp
-	default:
-		panic("invalid RowFeature")
 	}
 }
 

--- a/slatedb/flatbuf_types.go
+++ b/slatedb/flatbuf_types.go
@@ -41,6 +41,8 @@ func (info *SSTableIndexData) clone() *SSTableIndexData {
 // FlatBufferSSTableInfoCodec
 // ------------------------------------------------
 
+// FlatBufferSSTableInfoCodec implements SsTableInfoCodec and defines how we
+// encode SSTableInfo to byte slice and decode byte slice back to SSTableInfo
 type FlatBufferSSTableInfoCodec struct{}
 
 func (f *FlatBufferSSTableInfoCodec) encode(info *SSTableInfo) []byte {
@@ -58,6 +60,8 @@ func (f *FlatBufferSSTableInfoCodec) decode(data []byte) *SSTableInfo {
 // FlatBufferManifestCodec
 // ------------------------------------------------
 
+// FlatBufferManifestCodec implements ManifestCodec and defines how we
+// encode Manifest to byte slice and decode byte slice back to Manifest
 type FlatBufferManifestCodec struct{}
 
 func (f FlatBufferManifestCodec) encode(manifest *Manifest) []byte {

--- a/slatedb/flush.go
+++ b/slatedb/flush.go
@@ -203,7 +203,7 @@ func (m *MemtableFlusher) writeManifestSafely() error {
 
 		err = m.writeManifest()
 		if errors.Is(err, common.ErrManifestVersionExists) {
-			logger.Error("conflicting manifest version. retry write", zap.Error(err))
+			logger.Warn("conflicting manifest version. retry write", zap.Error(err))
 		} else if err != nil {
 			return err
 		} else {

--- a/slatedb/manifest_store.go
+++ b/slatedb/manifest_store.go
@@ -72,7 +72,7 @@ func initFenceableManifestCompactor(storedManifest *StoredManifest) (*FenceableM
 func (f *FenceableManifest) dbState() (*CoreDBState, error) {
 	err := f.checkEpoch()
 	if err != nil {
-		logger.Error("unable to get db state", zap.Error(err))
+		logger.Warn("unable to get db state", zap.Error(err))
 		return nil, err
 	}
 	return f.storedManifest.dbState(), nil
@@ -104,7 +104,7 @@ func (f *FenceableManifest) storedEpoch() uint64 {
 
 func (f *FenceableManifest) checkEpoch() error {
 	if f.localEpoch.Load() < f.storedEpoch() {
-		logger.Warn("detenced newer client")
+		logger.Warn("detected newer client")
 		return common.ErrFenced
 	}
 	if f.localEpoch.Load() > f.storedEpoch() {
@@ -181,7 +181,7 @@ func (s *StoredManifest) updateManifest(manifest *Manifest) error {
 	newID := s.id + 1
 	err := s.manifestStore.writeManifest(newID, manifest)
 	if err != nil {
-		logger.Error("unable to write store manifest", zap.Error(err))
+		logger.Warn("unable to write store manifest", zap.Error(err))
 		return err
 	}
 	s.manifest = manifest
@@ -231,7 +231,7 @@ func (s *ManifestStore) writeManifest(id uint64, manifest *Manifest) error {
 	filepath := s.manifestPath(fmt.Sprintf("%020d.%s", id, s.manifestSuffix))
 	err := s.objectStore.putIfNotExists(filepath, s.codec.encode(manifest))
 	if err != nil {
-		logger.Error("failed to complete the operation", zap.Error(err))
+		logger.Warn("failed objectStore.putIfNotExists", zap.Error(err))
 		if errors.Is(err, common.ErrObjectExists) {
 			return common.ErrManifestVersionExists
 		}

--- a/slatedb/object_store.go
+++ b/slatedb/object_store.go
@@ -48,7 +48,6 @@ func (d *DelegatingObjectStore) putIfNotExists(objPath string, data []byte) erro
 	}
 
 	if exists {
-		logger.Warn("object store already exists")
 		return common.ErrObjectExists
 	}
 

--- a/slatedb/sst.go
+++ b/slatedb/sst.go
@@ -83,6 +83,10 @@ func (f *SSTableFormat) readFilter(info *SSTableInfoOwned, obj common.ReadOnlyBl
 	return mo.Some(*filtr), nil
 }
 
+func (f *SSTableFormat) readIndex(infoOwned *SSTableInfoOwned, obj common.ReadOnlyBlob) (*SSTableIndexOwned, error) {
+	info := infoOwned.borrow()
+}
+
 // decompress the compressed data using the specified compression codec.
 // TODO: implement more compression options
 func (f *SSTableFormat) decompress(compressedData []byte, compression CompressionCodec) ([]byte, error) {
@@ -416,29 +420,9 @@ func (b *EncodedSSTableBuilder) build() (*EncodedSSTable, error) {
 // SSTableInfoOwned
 // ------------------------------------------------
 
-type SSTableInfoOwned struct {
-	data []byte
-}
-
-func newSSTableInfoOwned(data []byte) *SSTableInfoOwned {
-	return &SSTableInfoOwned{data: data}
-}
-
-func (info *SSTableInfoOwned) borrow() *flatbuf.SsTableInfo {
-	return flatbuf.GetRootAsSsTableInfo(info.data, 0)
-}
-
 func (info *SSTableInfoOwned) encode(buf *[]byte) {
 	*buf = append(*buf, info.data...)
 	*buf = binary.BigEndian.AppendUint32(*buf, crc32.ChecksumIEEE(info.data))
-}
-
-func (info *SSTableInfoOwned) clone() *SSTableInfoOwned {
-	data := make([]byte, len(info.data))
-	copy(data, info.data)
-	return &SSTableInfoOwned{
-		data: data,
-	}
 }
 
 func decodeBytesToSSTableInfo(rawBlockMeta []byte) (*SSTableInfoOwned, error) {

--- a/slatedb/sst.go
+++ b/slatedb/sst.go
@@ -25,8 +25,9 @@ import (
 // ------------------------------------------------
 
 type SSTableFormat struct {
-	blockSize        uint64
-	minFilterKeys    uint32
+	blockSize     uint64
+	minFilterKeys uint32
+	sstCodec
 	compressionCodec CompressionCodec
 }
 
@@ -83,7 +84,7 @@ func (f *SSTableFormat) readFilter(info *SSTableInfoOwned, obj common.ReadOnlyBl
 	return mo.Some(*filtr), nil
 }
 
-func (f *SSTableFormat) readIndex(infoOwned *SSTableInfoOwned, obj common.ReadOnlyBlob) (*SSTableIndexOwned, error) {
+func (f *SSTableFormat) readIndex(infoOwned *SSTableInfoOwned, obj common.ReadOnlyBlob) (*SSTableIndexData, error) {
 	info := infoOwned.borrow()
 }
 

--- a/slatedb/table_store.go
+++ b/slatedb/table_store.go
@@ -21,7 +21,7 @@ import (
 
 // ------------------------------------------------
 // TableStore is an abstraction over object storage
-// to read/write data
+// to read/write SSTable data
 // ------------------------------------------------
 
 type TableStore struct {

--- a/slatedb/table_store_test.go
+++ b/slatedb/table_store_test.go
@@ -11,7 +11,9 @@ import (
 
 func TestSSTWriter(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	format := newSSTableFormat(32, 1, CompressionNone)
+	format := defaultSSTableFormat()
+	format.blockSize = 32
+	format.filterBitsPerKey = 1
 	tableStore := newTableStore(bucket, format, "")
 	sstID := newSSTableIDCompacted(ulid.Make())
 
@@ -23,7 +25,8 @@ func TestSSTWriter(t *testing.T) {
 	sst, err := writer.close()
 	assert.NoError(t, err)
 
-	iterator := newSSTIterator(sst, tableStore, 1, 1)
+	iterator, err := newSSTIterator(sst, tableStore, 1, 1)
+	assert.NoError(t, err)
 	iter.AssertIterNextEntry(t, iterator, []byte("aaaaaaaaaaaaaaaa"), []byte("1111111111111111"))
 	iter.AssertIterNextEntry(t, iterator, []byte("bbbbbbbbbbbbbbbb"), []byte("2222222222222222"))
 	iter.AssertIterNextEntry(t, iterator, []byte("cccccccccccccccc"), nil)


### PR DESCRIPTION
1. This patch moves the sst index out of the sst info footer and into its own data block . We load the index by reading it from the sst only when its needed.

2. Currently SSTs do not store any information about the compression codec they are written with. Therefore, if we change the compression codec, we have no way of knowing how to decompress the data in a given SST. We should:

write the compression codec used for a given SST into the SST's info footer
consult the info when reading an sst block and use the specified compression codec to decompress blocks