### PR TITLE
Rename AwaitFlush to AwaitDurable

### DIFF
--- a/docs/adr/0003-read-and-write-sequence.md
+++ b/docs/adr/0003-read-and-write-sequence.md
@@ -19,7 +19,7 @@ When the DB is opened, we start 3 background goroutines:
 3. Compactor (compact L0 level to further levels/SortedRuns)
 
 ### Sequence of ops for PUT
-(Assumption AwaitFlush is true i.e. PUT will wait till write is durably committed)
+(Assumption AwaitDurable is true i.e. PUT will wait till write is durably committed)
 
 1. Write KV to WAL
 2. Every FlushInterval duration, a background goroutine WALFLushTask will do the following:

--- a/slatedb/config.go
+++ b/slatedb/config.go
@@ -119,12 +119,12 @@ func DefaultReadOptions() ReadOptions {
 type WriteOptions struct {
 	// Whether `put` calls should block until the write has been durably committed
 	// to the DB.
-	AwaitFlush bool
+	AwaitDurable bool
 }
 
 func DefaultWriteOptions() WriteOptions {
 	return WriteOptions{
-		AwaitFlush: true,
+		AwaitDurable: true,
 	}
 }
 

--- a/slatedb/db.go
+++ b/slatedb/db.go
@@ -116,7 +116,7 @@ func (db *DB) PutWithOptions(key []byte, value []byte, options WriteOptions) {
 	assert.True(len(key) > 0, "key cannot be empty")
 
 	currentWAL := db.state.PutKVToWAL(key, value)
-	if options.AwaitFlush {
+	if options.AwaitDurable {
 		// we wait for WAL to be flushed to memtable and then we send a notification
 		// to goroutine to flush memtable to L0. we do not wait till its flushed to L0
 		// because client can read the key from memtable
@@ -214,7 +214,7 @@ func (db *DB) DeleteWithOptions(key []byte, options WriteOptions) {
 	assert.True(len(key) > 0, "key cannot be empty")
 
 	currentWAL := db.state.DeleteKVFromWAL(key)
-	if options.AwaitFlush {
+	if options.AwaitDurable {
 		currentWAL.Table().AwaitWALFlush()
 	}
 }

--- a/slatedb/db_test.go
+++ b/slatedb/db_test.go
@@ -267,7 +267,7 @@ func TestShouldReadUncommittedIfReadLevelUncommitted(t *testing.T) {
 	defer db.Close()
 
 	// we do not wait till WAL is flushed to object store and memtable
-	db.PutWithOptions([]byte("foo"), []byte("bar"), WriteOptions{AwaitFlush: false})
+	db.PutWithOptions([]byte("foo"), []byte("bar"), WriteOptions{AwaitDurable: false})
 
 	value, err := db.GetWithOptions([]byte("foo"), ReadOptions{ReadLevel: Uncommitted})
 	assert.NoError(t, err)
@@ -282,7 +282,7 @@ func TestShouldReadOnlyCommittedData(t *testing.T) {
 	defer db.Close()
 
 	db.Put([]byte("foo"), []byte("bar"))
-	db.PutWithOptions([]byte("foo"), []byte("bla"), WriteOptions{AwaitFlush: false})
+	db.PutWithOptions([]byte("foo"), []byte("bla"), WriteOptions{AwaitDurable: false})
 
 	value, err := db.Get([]byte("foo"))
 	assert.NoError(t, err)
@@ -301,7 +301,7 @@ func TestShouldDeleteWithoutAwaitingFlush(t *testing.T) {
 	defer db.Close()
 
 	db.Put([]byte("foo"), []byte("bar"))
-	db.DeleteWithOptions([]byte("foo"), WriteOptions{AwaitFlush: false})
+	db.DeleteWithOptions([]byte("foo"), WriteOptions{AwaitDurable: false})
 
 	value, err := db.Get([]byte("foo"))
 	assert.NoError(t, err)

--- a/slatedb/flush.go
+++ b/slatedb/flush.go
@@ -50,7 +50,7 @@ func (db *DB) FlushWAL() error {
 // Flush Immutable WAL to Object store
 // Flush Immutable WAL to mutable Memtable
 // If memtable has reached size L0SSTBytes then convert memtable to Immutable memtable
-// Notify any client(with AwaitFlush set to true) that flush has happened
+// Notify any client(with AwaitDurable set to true) that flush has happened
 func (db *DB) flushImmWALs() error {
 	for {
 		oldestWal := db.state.oldestImmWAL()


### PR DESCRIPTION
Rename to stay consistent with Rust implementation
https://github.com/slatedb/slatedb/blob/main/src/config.rs#L238
