### PR TITLE
Fix race condition in sstable.Iterator

### DIFF
--- a/docs/adr/0002-design-goals.md
+++ b/docs/adr/0002-design-goals.md
@@ -8,37 +8,42 @@ Accepted
 
 ## Context
 
-Understanding the high level goals of the project is important information for contributors and users alike. This
-allows us to focus on what is important and not get side tracked with implementing features which clash with the
-primary goals of the project.
+Understanding the high level goals of the project is important information for
+contributors and users alike. This allows us to focus on what is important and
+not get side tracked with implementing features which clash with the primary
+goals of the project.
 
 ## Decision
 
-The primary goal of the project is to implement an LSM based key value store which is intended to be used
-for OLTP workloads backed by object storage systems like S3. 
+The primary goal of the project is to implement an LSM (Log-Structured Merge)
+based key-value store, which is intended to be used for OLTP (Online
+Transaction Processing) workloads backed by object storage systems like S3.
 
-Primary feature set includes
-- Support for [Strict Serializability](https://jepsen.io/consistency/models/strong-serializable) - Which 
-  allows users to have the strongest consistency guarantees, ensuring that transactions appear to execute 
-  atomically and in a total order that respects real-time ordering of operations.
-- Support for Range Queries - Allows a user to search for all keys starting from a certain point and 
-  ending at another, effectively retrieving a continuous sequence of data based on key order.
-- Support for a Merge Operator - Allows a user to build efficient streaming operations through the use 
-  of Atomic Read-Modify-Write operations on key values.
+Primary feature set includes:
+- **Support for Transactions**: To ensure database consistency, and durability.
+- **Support for Range Queries**: Allows a user to search for all keys starting
+  from a certain point and ending at another, effectively retrieving a
+  continuous sequence of data based on key order.
+- **Support for a Merge Operator**: Allows a user to build efficient streaming
+  operations through the use of Atomic Read-Modify-Write operations on key
+  values.
 
 ### Configurability
-Since slateDB is primarily backed by object storage systems, it will provide configurable options to
-tune latency, throughput and durability depending on the user workload.
+Since slateDB is primarily backed by object storage systems, it will provide
+configurable options to tune latency, throughput and durability depending on
+the user workload.
 
 ### Expected use case
-For golang, we expect slateDB will be used for event processing and event capture workloads. As such, 
-much of the design goals revolves around solving for that use case.
+For golang, we expect slateDB will be used for event processing and event
+capture workloads. As such, much of the design goals revolves around solving
+for that use case.
 
 TODO: Other expected use cases?
 
 ## Consequences
 
-SlateDB is not intended to solve write synchronization, nor provide a network protocol for interacting
-with SlateDB, nor support long-running transactions for use in non database synchronization. Users will need 
-to implement multi-client synchronization and partitioning schemes which make sense for their workloads and 
-achieve their throughput and availability goals.
+SlateDB is not intended to solve write synchronization, nor provide a network
+protocol for interacting with SlateDB, nor support long-running transactions
+for use in non database synchronization. Users will need to implement
+multi-client synchronization and partitioning schemes which make sense for
+their workloads and achieve their throughput and availability goals.

--- a/internal/sstable/decode.go
+++ b/internal/sstable/decode.go
@@ -130,7 +130,7 @@ func ReadBlocks(info *Info, index *Index, r common.Range, obj common.ReadOnlyBlo
 	}
 
 	startOffset := rng.Start
-	decodedBlocks := make([]block.Block, 0)
+	var decodedBlocks []block.Block
 	blockMetaList := index.BlockMeta()
 	compressionCodec := info.CompressionCodec
 

--- a/internal/sstable/iterator.go
+++ b/internal/sstable/iterator.go
@@ -3,13 +3,9 @@ package sstable
 import (
 	"bytes"
 	"fmt"
-	"github.com/samber/mo"
-	"github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/sstable/block"
 	"github.com/slatedb/slatedb-go/internal/types"
 	"github.com/slatedb/slatedb-go/slatedb/common"
-	"math"
-	"sync"
 )
 
 type TableStore interface {
@@ -17,68 +13,44 @@ type TableStore interface {
 	ReadBlocksUsingIndex(*Handle, common.Range, *Index) ([]block.Block, error)
 }
 
-// Iterator helps in iterating through KeyValue pairs present in the SSTable.
-// Since each SSTable is a list of Blocks, this iterator internally uses block.Iterator to iterate through each Block
+// Iterator iterates through KeyValue pairs present in the SSTable.
 type Iterator struct {
-	table               *Handle
-	indexData           *Index
-	tableStore          TableStore
-	currentBlockIter    mo.Option[*block.Iterator]
-	fromKey             mo.Option[[]byte]
-	nextBlockIdxToFetch uint64
-	fetchTasks          chan chan mo.Option[[]block.Block]
-	maxFetchTasks       uint64
-	numBlocksToFetch    uint64
-	warn                types.ErrWarn
+	blockIter *block.Iterator
+	warn      types.ErrWarn
+	store     TableStore
+	handle    *Handle
+	index     *Index
+	fromKey   []byte
+	nextBlock uint64
 }
 
-func NewIterator(
-	table *Handle,
-	tableStore TableStore,
-	maxFetchTasks uint64,
-	numBlocksToFetch uint64,
-) (*Iterator, error) {
-	indexData, err := tableStore.ReadIndex(table)
+func NewIterator(handle *Handle, store TableStore) (*Iterator, error) {
+	index, err := store.ReadIndex(handle)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Iterator{
-		table:               table,
-		indexData:           indexData,
-		tableStore:          tableStore,
-		currentBlockIter:    mo.None[*block.Iterator](),
-		fromKey:             mo.None[[]byte](),
-		nextBlockIdxToFetch: 0,
-		fetchTasks:          make(chan chan mo.Option[[]block.Block], maxFetchTasks),
-		maxFetchTasks:       maxFetchTasks,
-		numBlocksToFetch:    numBlocksToFetch,
+		handle:    handle,
+		store:     store,
+		index:     index,
+		nextBlock: 0,
 	}, nil
 }
 
-func NewIteratorAtKey(
-	table *Handle,
-	fromKey []byte,
-	tableStore TableStore,
-	maxFetchTasks uint64,
-	numBlocksToFetch uint64,
-) (*Iterator, error) {
-	indexData, err := tableStore.ReadIndex(table)
+func NewIteratorAtKey(handle *Handle, key []byte, store TableStore) (*Iterator, error) {
+	index, err := store.ReadIndex(handle)
 	if err != nil {
 		return nil, err
 	}
 
 	iter := &Iterator{
-		table:            table,
-		indexData:        indexData,
-		tableStore:       tableStore,
-		currentBlockIter: mo.None[*block.Iterator](),
-		fromKey:          mo.Some(fromKey),
-		fetchTasks:       make(chan chan mo.Option[[]block.Block], maxFetchTasks),
-		maxFetchTasks:    maxFetchTasks,
-		numBlocksToFetch: numBlocksToFetch,
+		fromKey: bytes.Clone(key),
+		handle:  handle,
+		store:   store,
+		index:   index,
 	}
-	iter.nextBlockIdxToFetch = iter.firstBlockWithDataIncludingOrAfterKey(indexData, fromKey)
+	iter.nextBlock = iter.firstBlockIncludingOrAfterKey(index, key)
 	return iter, nil
 }
 
@@ -102,28 +74,29 @@ func (iter *Iterator) Next() (types.KeyValue, bool) {
 
 func (iter *Iterator) NextEntry() (types.RowEntry, bool) {
 	for {
-		if iter.currentBlockIter.IsAbsent() {
-			nextBlockIter, err := iter.nextBlockIter()
+		if iter.blockIter == nil {
+			it, err := iter.nextBlockIter()
 			if err != nil {
+				// TODO(thrawn01): This could be a transient error, or a corruption error
+				//  we need to handle each differently.
+				iter.warn.Add("while fetching blocks for SST '%s': %s",
+					iter.handle.Id.String(), err.Error())
 				return types.RowEntry{}, false
 			}
-
-			if nextBlockIter.IsPresent() {
-				iter.currentBlockIter = nextBlockIter
-			} else {
+			if it == nil { // No more blocks
 				return types.RowEntry{}, false
 			}
+			iter.blockIter = it
 		}
 
-		currentBlockIter, _ := iter.currentBlockIter.Get()
-		kv, ok := currentBlockIter.NextEntry()
+		kv, ok := iter.blockIter.NextEntry()
 		if !ok {
-			if warn := currentBlockIter.Warnings(); warn != nil {
+			if warn := iter.blockIter.Warnings(); warn != nil {
 				iter.warn.Merge(warn)
 			}
 			// We have exhausted the current block, but not necessarily the entire SST,
 			// so we fall back to the top to check if we have more blocks to read.
-			iter.currentBlockIter = mo.None[*block.Iterator]()
+			iter.blockIter = nil
 			continue
 		}
 
@@ -131,108 +104,63 @@ func (iter *Iterator) NextEntry() (types.RowEntry, bool) {
 	}
 }
 
-// SpawnFetches - Each SST has multiple blocks, this method will create goroutines to fetch blocks within a range
-// Range{blocksStart, blocksEnd} for a given SST from object storage
-// TODO(thrawn01): This is called from compaction, we should instead call it from the constructor and it should be
-//   - made private to this struct
-func (iter *Iterator) SpawnFetches() {
-
-	numBlocks := iter.indexData.BlockMetaLength()
-	table := iter.table.Clone()
-	// TODO(thrawn01): I don't believe we want to clone the store here. this
-	//  this invalidates the cache and the mutex of the store, which likely
-	//  will cause a race in TableStore.
-	tableStore := iter.tableStore
-	index := iter.indexData.Clone()
-	var wg sync.WaitGroup
-
-	for len(iter.fetchTasks) < int(iter.maxFetchTasks) && int(iter.nextBlockIdxToFetch) < numBlocks {
-		numBlocksToFetch := math.Min(
-			float64(iter.numBlocksToFetch),
-			float64(numBlocks-int(iter.nextBlockIdxToFetch)),
-		)
-		blocksStart := iter.nextBlockIdxToFetch
-		blocksEnd := iter.nextBlockIdxToFetch + uint64(numBlocksToFetch)
-
-		blocksCh := make(chan mo.Option[[]block.Block], 1)
-		iter.fetchTasks <- blocksCh
-
-		blocksRange := common.Range{Start: blocksStart, End: blocksEnd}
-
-		wg.Add(1)
-		go func() {
-			blocks, err := tableStore.ReadBlocksUsingIndex(table, blocksRange, index)
-			if err != nil {
-				// TODO(thrawn01): handle error
-				blocksCh <- mo.None[[]block.Block]()
-			} else {
-				blocksCh <- mo.Some(blocks)
-			}
-			wg.Done()
-		}()
-		wg.Wait()
-
-		iter.nextBlockIdxToFetch = blocksEnd
+// nextBlockIter fetches the next block and returns an iterator for that block
+func (iter *Iterator) nextBlockIter() (*block.Iterator, error) {
+	if iter.nextBlock >= uint64(iter.index.BlockMetaLength()) {
+		return nil, nil // No more blocks to read
 	}
+
+	// Fetch the next block
+	rng := common.Range{Start: iter.nextBlock, End: iter.nextBlock + 1}
+	blocks, err := iter.store.ReadBlocksUsingIndex(iter.handle, rng, iter.index)
+	if err != nil {
+		return nil, fmt.Errorf("while reading block range [%d:%d]: %w", rng.Start, rng.End, err)
+	}
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("block read range [%d:%d] returned zero blocks", rng.Start, rng.End)
+	}
+
+	// Increment the iter.nextBlock
+	iter.nextBlock++
+
+	// If iter.fromKey is present use NewIteratorAtKey() to find the key in the block
+	if iter.fromKey != nil {
+		// Will return an iterator nearest to where the key should be if it doesn't exist.
+		return block.NewIteratorAtKey(&blocks[0], iter.fromKey)
+	}
+
+	// Iterate through all the blocks
+	return block.NewIterator(&blocks[0]), nil
 }
 
-func (iter *Iterator) nextBlockIter() (mo.Option[*block.Iterator], error) {
-	for {
-		iter.SpawnFetches()
-		// TODO(thrawn01): This is a race, we should not expect an empty channel to indicate there are no more
-		//  items to process.
-		if len(iter.fetchTasks) == 0 {
-			assert.True(int(iter.nextBlockIdxToFetch) == iter.indexData.BlockMetaLength(), "")
-			fmt.Printf("Iteration Stopped Due To Empty Task Channel\n")
-			return mo.None[*block.Iterator](), nil
-		}
-
-		blocksCh := <-iter.fetchTasks
-		blocks := <-blocksCh
-		if blocks.IsPresent() {
-			blks, _ := blocks.Get()
-			if len(blks) == 0 {
-				continue
-			}
-
-			b := &blks[0]
-			fromKey, _ := iter.fromKey.Get()
-			if iter.fromKey.IsPresent() {
-				// TODO(thrawn01): Handle this error
-				it, _ := block.NewIteratorAtKey(b, fromKey)
-				return mo.Some(it), nil
-			} else {
-				return mo.Some(block.NewIterator(b)), nil
-			}
-		} else {
-			// TODO(thrawn01): Return the actual error which occurred.
-			return mo.None[*block.Iterator](), common.ErrReadBlocks
-		}
-	}
-}
-
-func (iter *Iterator) firstBlockWithDataIncludingOrAfterKey(index *Index, key []byte) uint64 {
+// firstBlockIncludingOrAfterKey performs a binary search on the SSTable index to find the first block
+// that either includes the given key or is the first block after the key. This ensures we start reading
+// from either the block containing the key or the first block that could contain keys greater than the search key.
+func (iter *Iterator) firstBlockIncludingOrAfterKey(index *Index, key []byte) uint64 {
 	low := 0
 	high := index.BlockMetaLength() - 1
-	// if the key is less than all the blocks' first key, scan the whole sst
 	foundBlockID := 0
 
 loop:
 	for low <= high {
 		mid := low + (high-low)/2
+		// Compare the middle block's first key with the search key.
 		midBlockFirstKey := index.BlockMeta()[mid].FirstKey
 		cmp := bytes.Compare(midBlockFirstKey, key)
 		switch cmp {
-		case -1:
+		// If the search key is greater, narrow the search to the upper half.
+		case -1: // key > midBlockFirstKey
 			low = mid + 1
 			foundBlockID = mid
-		case 1:
+		// If the search key is smaller, narrow the search to the lower half.
+		case 1: // key < midBlockFirstKey
 			if mid > 0 {
 				high = mid - 1
 			} else {
 				break loop
 			}
-		case 0:
+		// If they're equal, we've found the exact block, return its index.
+		case 0: // exact match
 			return uint64(mid)
 		}
 	}

--- a/internal/sstable/table.go
+++ b/internal/sstable/table.go
@@ -58,6 +58,9 @@ func (s *ID) CompactedID() mo.Option[ulid.ULID] {
 
 	return mo.Some(val)
 }
+func (s *ID) String() string {
+	return s.Value
+}
 
 func (s *ID) Clone() ID {
 	var sstID ID
@@ -71,8 +74,8 @@ func (s *ID) Clone() ID {
 	return sstID
 }
 
-// Handle represents the SSTable
-// TODO(thrawn01): I think this should merge with sstable.Table
+// Handle is a reference to an SSTable, which does not contain the actual
+// SST data. It can represent both WALs and Compacted SSTs
 type Handle struct {
 	Id   ID
 	Info *Info

--- a/slatedb/compactor.go
+++ b/slatedb/compactor.go
@@ -364,25 +364,18 @@ func (e *CompactionExecutor) loadIterators(compaction CompactionJob) (iter.KVIte
 
 	l0Iters := make([]iter.KVIterator, 0)
 	for _, sst := range compaction.sstList {
-		sstIter, err := sstable.NewIterator(&sst, e.tableStore.Clone(), 4, 256)
+		sstIter, err := sstable.NewIterator(&sst, e.tableStore.Clone())
 		if err != nil {
 			return nil, err
 		}
-
-		sstIter.SpawnFetches()
 		l0Iters = append(l0Iters, sstIter)
 	}
 
 	srIters := make([]iter.KVIterator, 0)
 	for _, sr := range compaction.sortedRuns {
-		srIter, err := newSortedRunIterator(sr, e.tableStore.Clone(), 16, 256)
+		srIter, err := newSortedRunIterator(sr, e.tableStore.Clone())
 		if err != nil {
 			return nil, err
-		}
-
-		if srIter.currentKVIter.IsPresent() {
-			sstIter, _ := srIter.currentKVIter.Get()
-			sstIter.SpawnFetches()
 		}
 		srIters = append(srIters, srIter)
 	}

--- a/slatedb/compactor_test.go
+++ b/slatedb/compactor_test.go
@@ -50,7 +50,7 @@ func TestCompactorCompactsL0(t *testing.T) {
 	assert.Equal(t, 1, len(compactedSSTList))
 
 	sst := compactedSSTList[0]
-	iter, err := sstable.NewIterator(&sst, tableStore, 1, 1)
+	iter, err := sstable.NewIterator(&sst, tableStore)
 	assert.NoError(t, err)
 	for i := 0; i < 4; i++ {
 		kv, ok := iter.Next()

--- a/slatedb/db.go
+++ b/slatedb/db.go
@@ -172,7 +172,7 @@ func (db *DB) GetWithOptions(key []byte, options ReadOptions) ([]byte, error) {
 	// search for key in SSTs in L0
 	for _, sst := range snapshot.core.l0 {
 		if db.sstMayIncludeKey(sst, key) {
-			iter, err := sstable.NewIteratorAtKey(&sst, key, db.tableStore.Clone(), 1, 1)
+			iter, err := sstable.NewIteratorAtKey(&sst, key, db.tableStore.Clone())
 			if err != nil {
 				return nil, err
 			}
@@ -187,7 +187,7 @@ func (db *DB) GetWithOptions(key []byte, options ReadOptions) ([]byte, error) {
 	// search for key in compacted Sorted runs
 	for _, sr := range snapshot.core.compacted {
 		if db.srMayIncludeKey(sr, key) {
-			iter, err := newSortedRunIteratorFromKey(sr, key, db.tableStore.Clone(), 1, 1)
+			iter, err := newSortedRunIteratorFromKey(sr, key, db.tableStore.Clone())
 			if err != nil {
 				return nil, err
 			}
@@ -260,7 +260,7 @@ func (db *DB) replayWAL() error {
 		assert.True(sst.Id.WalID().IsPresent(), "Invalid WAL ID")
 
 		// iterate through kv pairs in sst and populate walReplayBuf
-		iter, err := sstable.NewIterator(sst, db.tableStore.Clone(), 1, 1)
+		iter, err := sstable.NewIterator(sst, db.tableStore.Clone())
 		if err != nil {
 			return err
 		}

--- a/slatedb/sortedrun_test.go
+++ b/slatedb/sortedrun_test.go
@@ -54,7 +54,7 @@ func TestOneSstSRIter(t *testing.T) {
 	assert.NoError(t, err)
 
 	sr := SortedRun{0, []sstable.Handle{*sstHandle}}
-	iterator, err := newSortedRunIterator(sr, tableStore, 1, 1)
+	iterator, err := newSortedRunIterator(sr, tableStore)
 	assert.NoError(t, err)
 	assert2.Next(t, iterator, []byte("key1"), []byte("value1"))
 	assert2.Next(t, iterator, []byte("key2"), []byte("value2"))
@@ -90,7 +90,7 @@ func TestManySstSRIter(t *testing.T) {
 	require.NoError(t, err)
 
 	sr := SortedRun{0, []sstable.Handle{*sstHandle, *sstHandle2}}
-	iterator, err := newSortedRunIterator(sr, tableStore, 1, 1)
+	iterator, err := newSortedRunIterator(sr, tableStore)
 	assert.NoError(t, err)
 	assert2.Next(t, iterator, []byte("key1"), []byte("value1"))
 	assert2.Next(t, iterator, []byte("key2"), []byte("value2"))
@@ -124,7 +124,7 @@ func TestSRIterFromKey(t *testing.T) {
 		fromKey := testCaseKeyGen.Next()
 		testCaseValGen.Next()
 
-		kvIter, err := newSortedRunIteratorFromKey(sr, fromKey, tableStore, 1, 1)
+		kvIter, err := newSortedRunIteratorFromKey(sr, fromKey, tableStore)
 		assert.NoError(t, err)
 
 		for j := 0; j < 30-i; j++ {
@@ -153,7 +153,7 @@ func TestSRIterFromKeyLowerThanRange(t *testing.T) {
 	sr, err := buildSRWithSSTs(3, 10, tableStore, keyGen, valGen)
 	require.NoError(t, err)
 
-	kvIter, err := newSortedRunIteratorFromKey(sr, []byte("aaaaaaaaaa"), tableStore, 1, 1)
+	kvIter, err := newSortedRunIteratorFromKey(sr, []byte("aaaaaaaaaa"), tableStore)
 	assert.NoError(t, err)
 
 	for j := 0; j < 30; j++ {
@@ -179,7 +179,7 @@ func TestSRIterFromKeyHigherThanRange(t *testing.T) {
 	sr, err := buildSRWithSSTs(3, 10, tableStore, keyGen, valGen)
 	require.NoError(t, err)
 
-	kvIter, err := newSortedRunIteratorFromKey(sr, []byte("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"), tableStore, 1, 1)
+	kvIter, err := newSortedRunIteratorFromKey(sr, []byte("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"), tableStore)
 	assert.NoError(t, err)
 	next, ok := kvIter.Next()
 	assert.False(t, ok)

--- a/slatedb/table_store_test.go
+++ b/slatedb/table_store_test.go
@@ -362,7 +362,7 @@ func TestOneBlockSSTIter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, index.BlockMetaLength())
 
-	iterator, err := sstable.NewIterator(sstHandle, tableStore, 1, 1)
+	iterator, err := sstable.NewIterator(sstHandle, tableStore)
 	assert.NoError(t, err)
 	assert2.Next(t, iterator, []byte("key1"), []byte("value1"))
 	assert2.Next(t, iterator, []byte("key2"), []byte("value2"))
@@ -396,7 +396,7 @@ func TestManyBlockSSTIter(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, index)
 
-	iterator, err := sstable.NewIterator(sstHandle, tableStore, 1, 1)
+	iterator, err := sstable.NewIterator(sstHandle, tableStore)
 	assert.NoError(t, err)
 	for i := 0; i < 1000; i++ {
 		key := []byte(fmt.Sprintf("key%d", i))
@@ -432,7 +432,7 @@ func TestIterFromKey(t *testing.T) {
 		expectedValGen := testCaseValGen.Clone()
 		fromKey := testCaseKeyGen.Next()
 		testCaseValGen.Next()
-		kvIter, err := sstable.NewIteratorAtKey(sst, fromKey, tableStore, 1, 1)
+		kvIter, err := sstable.NewIteratorAtKey(sst, fromKey, tableStore)
 		assert.NoError(t, err)
 
 		for j := 0; j < nKeys-i; j++ {
@@ -462,7 +462,7 @@ func TestIterFromKeySmallerThanFirst(t *testing.T) {
 	sst, nKeys, err := buildSSTWithNBlocks(2, tableStore, keyGen, valGen)
 	require.NoError(t, err)
 
-	kvIter, err := sstable.NewIteratorAtKey(sst, []byte("aaaaaaaaaaaaaaaa"), tableStore, 1, 1)
+	kvIter, err := sstable.NewIteratorAtKey(sst, []byte("aaaaaaaaaaaaaaaa"), tableStore)
 	assert.NoError(t, err)
 
 	for i := 0; i < nKeys; i++ {
@@ -486,7 +486,7 @@ func TestIterFromKeyLargerThanLast(t *testing.T) {
 
 	sst, _, err := buildSSTWithNBlocks(2, tableStore, keyGen, valGen)
 	require.NoError(t, err)
-	kvIter, err := sstable.NewIteratorAtKey(sst, []byte("zzzzzzzzzzzzzzzz"), tableStore, 1, 1)
+	kvIter, err := sstable.NewIteratorAtKey(sst, []byte("zzzzzzzzzzzzzzzz"), tableStore)
 	assert.NoError(t, err)
 
 	_, ok := kvIter.Next()
@@ -553,7 +553,7 @@ func TestSSTWriter(t *testing.T) {
 	sst, err := writer.Close()
 	assert.NoError(t, err)
 
-	iterator, err := sstable.NewIterator(sst, tableStore, 1, 1)
+	iterator, err := sstable.NewIterator(sst, tableStore)
 	assert.NoError(t, err)
 	assert2.NextEntry(t, iterator, []byte("aaaaaaaaaaaaaaaa"), []byte("1111111111111111"))
 	assert2.NextEntry(t, iterator, []byte("bbbbbbbbbbbbbbbb"), []byte("2222222222222222"))


### PR DESCRIPTION
### Purpose
To fix the race condition in the code base causing the compaction test to flap. 

### Implementation
- Removed concurrent block fetch from `sstable.Iterator`
- Changed wording in `design-goals.md` document, as we are likely not implemention Strict Serializability.
- Added documentation for `firstBlockIncludingOrAfterKey()` and simplified the name.
