### PR TITLE
Added context to iterators and Get() calls

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/slatedb/slatedb-go/slatedb"
 	"github.com/thanos-io/objstore"
@@ -11,7 +13,9 @@ import (
 func main() {
 
 	bucket := objstore.NewInMemBucket()
-	db, _ := slatedb.Open("/tmp/testDB", bucket)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	db, _ := slatedb.Open(ctx, "/tmp/testDB", bucket)
 
 	key := []byte("key1")
 	value := []byte("value1")
@@ -19,11 +23,11 @@ func main() {
 	db.Put(key, value)
 	fmt.Println("Put:", string(key), string(value))
 
-	data, _ := db.Get(key)
+	data, _ := db.Get(ctx, key)
 	fmt.Println("Get:", string(key), string(data))
 
 	db.Delete(key)
-	_, err := db.Get(key)
+	_, err := db.Get(ctx, key)
 	if err != nil && err.Error() == "key not found" {
 		fmt.Println("Delete:", string(key))
 	} else {

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,6 +1,7 @@
 package assert
 
 import (
+	"context"
 	"fmt"
 	"github.com/slatedb/slatedb-go/internal/iter"
 	assert2 "github.com/stretchr/testify/assert"
@@ -16,7 +17,7 @@ func True(condition bool, errMsg string, arg ...any) {
 // NextEntry is a test helper to assert the next call to NextEntry() returns the required value
 func NextEntry(t *testing.T, iter iter.KVIterator, key []byte, value []byte) {
 	t.Helper()
-	entry, ok := iter.NextEntry()
+	entry, ok := iter.NextEntry(context.Background())
 	assert2.True(t, ok)
 	assert2.Equal(t, key, entry.Key)
 	if value == nil {
@@ -31,7 +32,7 @@ func NextEntry(t *testing.T, iter iter.KVIterator, key []byte, value []byte) {
 // Next is a test helper to assert the next call to Next() returns the required value
 func Next(t *testing.T, iter iter.KVIterator, key []byte, value []byte) bool {
 	t.Helper()
-	kv, _ := iter.Next()
+	kv, _ := iter.Next(context.Background())
 	//assert.True(t, ok)
 	if !assert2.Equal(t, key, kv.Key) {
 		return false

--- a/internal/iter/entry.go
+++ b/internal/iter/entry.go
@@ -1,16 +1,17 @@
 package iter
 
 import (
+	"context"
 	"github.com/slatedb/slatedb-go/internal/types"
 )
 
 type KVIterator interface {
 	// Next Returns the next non-deleted key-value pair in the iterator.
-	Next() (types.KeyValue, bool)
+	Next(context.Context) (types.KeyValue, bool)
 
 	// NextEntry Returns the next entry in the iterator, which may be a key-value pair or
 	// a tombstone of a deleted key-value pair.
-	NextEntry() (types.RowEntry, bool)
+	NextEntry(context.Context) (types.RowEntry, bool)
 
 	// Warnings returns any warnings issued during iteration which should be logged by the caller
 	Warnings() *types.ErrWarn
@@ -30,7 +31,7 @@ func NewEntryIterator(entries ...types.RowEntry) *EntryIterator {
 	}
 }
 
-func (k *EntryIterator) Next() (types.KeyValue, bool) {
+func (k *EntryIterator) Next(ctx context.Context) (types.KeyValue, bool) {
 	for k.index < len(k.entries) {
 		entry := k.entries[k.index]
 		k.index++
@@ -41,7 +42,7 @@ func (k *EntryIterator) Next() (types.KeyValue, bool) {
 	return types.KeyValue{}, false
 }
 
-func (k *EntryIterator) NextEntry() (types.RowEntry, bool) {
+func (k *EntryIterator) NextEntry(ctx context.Context) (types.RowEntry, bool) {
 	if k.index < len(k.entries) {
 		entry := k.entries[k.index]
 		k.index++

--- a/internal/iter/entry_test.go
+++ b/internal/iter/entry_test.go
@@ -1,6 +1,7 @@
 package iter_test
 
 import (
+	"context"
 	"github.com/slatedb/slatedb-go/internal/iter"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -19,20 +20,20 @@ func TestNewEntryIterator(t *testing.T) {
 	assert.Equal(t, 2, it.Len())
 
 	// Verify the first entry
-	entry1, ok := it.NextEntry()
+	entry1, ok := it.NextEntry(context.Background())
 	assert.True(t, ok)
 	assert.Equal(t, []byte("key1"), entry1.Key)
 	assert.Equal(t, []byte("value1"), entry1.Value.Value)
 	assert.False(t, entry1.Value.IsTombstone())
 
 	// Verify the second entry
-	entry2, ok := it.NextEntry()
+	entry2, ok := it.NextEntry(context.Background())
 	assert.True(t, ok)
 	assert.Equal(t, []byte("key2"), entry2.Key)
 	assert.Equal(t, []byte("value2"), entry2.Value.Value)
 	assert.False(t, entry2.Value.IsTombstone())
 
 	// Verify that the iterator is now empty
-	_, ok = it.NextEntry()
+	_, ok = it.NextEntry(context.Background())
 	assert.False(t, ok)
 }

--- a/internal/iter/merge_test.go
+++ b/internal/iter/merge_test.go
@@ -1,6 +1,7 @@
 package iter_test
 
 import (
+	"context"
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/iter"
 	"github.com/stretchr/testify/assert"
@@ -23,13 +24,13 @@ func TestMergeUniqueIteratorPrecedence(t *testing.T) {
 		Add([]byte("xxxx"), []byte("badx1")),
 	)
 
-	mergeIter := iter.NewMergeSort(iters...)
+	mergeIter := iter.NewMergeSort(context.Background(), iters...)
 	assert2.NextEntry(t, mergeIter, []byte("aaaa"), []byte("1111"))
 	assert2.NextEntry(t, mergeIter, []byte("bbbb"), []byte("2222"))
 	assert2.NextEntry(t, mergeIter, []byte("cccc"), []byte("use this one c"))
 	assert2.NextEntry(t, mergeIter, []byte("xxxx"), []byte("use this one x"))
 
-	_, ok := mergeIter.Next()
+	_, ok := mergeIter.Next(context.Background())
 	assert.False(t, ok, "Expected no more entries")
 }
 
@@ -51,7 +52,7 @@ func TestMergeUnique(t *testing.T) {
 		Add([]byte("gggg"), []byte("7777")),
 	)
 
-	mergeIter := iter.NewMergeSort(iters...)
+	mergeIter := iter.NewMergeSort(context.Background(), iters...)
 	assert2.NextEntry(t, mergeIter, []byte("aaaa"), []byte("1111"))
 	assert2.NextEntry(t, mergeIter, []byte("bbbb"), []byte("2222"))
 	assert2.NextEntry(t, mergeIter, []byte("cccc"), []byte("3333"))
@@ -62,7 +63,7 @@ func TestMergeUnique(t *testing.T) {
 	assert2.NextEntry(t, mergeIter, []byte("yyyy"), []byte("25252525"))
 	assert2.NextEntry(t, mergeIter, []byte("zzzz"), []byte("26262626"))
 
-	_, ok := mergeIter.Next()
+	_, ok := mergeIter.Next(context.Background())
 	assert.False(t, ok, "Expected no more entries")
 }
 
@@ -77,7 +78,7 @@ func TestMergeSortTwoIterators(t *testing.T) {
 		Add([]byte("xxxx"), []byte("24242424")).
 		Add([]byte("yyyy"), []byte("25252525"))
 
-	mergeIter := iter.NewMergeSort(iter1, iter2)
+	mergeIter := iter.NewMergeSort(context.Background(), iter1, iter2)
 	assert2.NextEntry(t, mergeIter, []byte("aaaa"), []byte("1111"))
 	assert2.NextEntry(t, mergeIter, []byte("bbbb"), []byte("2222"))
 	assert2.NextEntry(t, mergeIter, []byte("cccc"), []byte("3333"))
@@ -85,7 +86,7 @@ func TestMergeSortTwoIterators(t *testing.T) {
 	assert2.NextEntry(t, mergeIter, []byte("yyyy"), []byte("25252525"))
 	assert2.NextEntry(t, mergeIter, []byte("zzzz"), []byte("26262626"))
 
-	_, ok := mergeIter.Next()
+	_, ok := mergeIter.Next(context.Background())
 	assert.False(t, ok, "Expected no more entries")
 }
 
@@ -98,11 +99,11 @@ func TestMergeSortTwoIteratorsPrecedence(t *testing.T) {
 		Add([]byte("cccc"), []byte("badc")).
 		Add([]byte("xxxx"), []byte("24242424"))
 
-	mergeIter := iter.NewMergeSort(iter1, iter2)
+	mergeIter := iter.NewMergeSort(context.Background(), iter1, iter2)
 	assert2.NextEntry(t, mergeIter, []byte("aaaa"), []byte("1111"))
 	assert2.NextEntry(t, mergeIter, []byte("cccc"), []byte("use this one c"))
 	assert2.NextEntry(t, mergeIter, []byte("xxxx"), []byte("24242424"))
 
-	_, ok := mergeIter.Next()
+	_, ok := mergeIter.Next(context.Background())
 	assert.False(t, ok, "Expected no more entries")
 }

--- a/internal/sstable/block/block.go
+++ b/internal/sstable/block/block.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -204,7 +205,7 @@ func PrettyPrint(block *Block) string {
 	buf := new(bytes.Buffer)
 	it := NewIterator(block)
 	for _, offset := range block.Offsets {
-		kv, ok := it.NextEntry()
+		kv, ok := it.NextEntry(context.Background())
 		if !ok {
 			if warn := it.Warnings(); warn != nil {
 				_, _ = fmt.Fprintf(buf, "WARN: %s\n", warn.String())
@@ -221,7 +222,7 @@ func PrettyPrint(block *Block) string {
 			_, _ = fmt.Fprintf(buf, "  Value: []byte(\"%s\") - %d bytes\n", Truncate(v, 30), len(v))
 		}
 	}
-	if _, ok := it.NextEntry(); ok {
+	if _, ok := it.NextEntry(context.Background()); ok {
 		_, _ = fmt.Fprintf(buf, "WARN: there are more blocks than offsets")
 	}
 	return buf.String()

--- a/internal/sstable/block/iterator.go
+++ b/internal/sstable/block/iterator.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"github.com/slatedb/slatedb-go/internal/types"
@@ -79,9 +80,9 @@ func NewIteratorAtKey(block *Block, key []byte) (*Iterator, error) {
 	}, nil
 }
 
-func (iter *Iterator) Next() (types.KeyValue, bool) {
+func (iter *Iterator) Next(ctx context.Context) (types.KeyValue, bool) {
 	for {
-		entry, ok := iter.NextEntry()
+		entry, ok := iter.NextEntry(ctx)
 		if !ok {
 			return types.KeyValue{}, false
 		}
@@ -95,7 +96,7 @@ func (iter *Iterator) Next() (types.KeyValue, bool) {
 	}
 }
 
-func (iter *Iterator) NextEntry() (types.RowEntry, bool) {
+func (iter *Iterator) NextEntry(ctx context.Context) (types.RowEntry, bool) {
 	if iter.offsetIndex >= uint64(len(iter.block.Offsets)) {
 		return types.RowEntry{}, false
 	}

--- a/internal/sstable/iterator.go
+++ b/internal/sstable/iterator.go
@@ -2,6 +2,7 @@ package sstable
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"github.com/slatedb/slatedb-go/internal/sstable/block"
 	"github.com/slatedb/slatedb-go/internal/types"
@@ -54,9 +55,9 @@ func NewIteratorAtKey(handle *Handle, key []byte, store TableStore) (*Iterator, 
 	return iter, nil
 }
 
-func (iter *Iterator) Next() (types.KeyValue, bool) {
+func (iter *Iterator) Next(ctx context.Context) (types.KeyValue, bool) {
 	for {
-		keyVal, ok := iter.NextEntry()
+		keyVal, ok := iter.NextEntry(ctx)
 		if !ok {
 			return types.KeyValue{}, false
 		}
@@ -72,7 +73,7 @@ func (iter *Iterator) Next() (types.KeyValue, bool) {
 	}
 }
 
-func (iter *Iterator) NextEntry() (types.RowEntry, bool) {
+func (iter *Iterator) NextEntry(ctx context.Context) (types.RowEntry, bool) {
 	for {
 		if iter.blockIter == nil {
 			it, err := iter.nextBlockIter()
@@ -89,7 +90,7 @@ func (iter *Iterator) NextEntry() (types.RowEntry, bool) {
 			iter.blockIter = it
 		}
 
-		kv, ok := iter.blockIter.NextEntry()
+		kv, ok := iter.blockIter.NextEntry(ctx)
 		if !ok {
 			if warn := iter.blockIter.Warnings(); warn != nil {
 				iter.warn.Merge(warn)

--- a/slatedb/compactor_test.go
+++ b/slatedb/compactor_test.go
@@ -1,6 +1,7 @@
 package slatedb
 
 import (
+	"context"
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/sstable"
@@ -53,19 +54,19 @@ func TestCompactorCompactsL0(t *testing.T) {
 	iter, err := sstable.NewIterator(&sst, tableStore)
 	assert.NoError(t, err)
 	for i := 0; i < 4; i++ {
-		kv, ok := iter.Next()
+		kv, ok := iter.Next(context.Background())
 		assert.True(t, ok)
 		assert.Equal(t, repeatedChar(rune('a'+i), 16), kv.Key)
 		assert.Equal(t, repeatedChar(rune('b'+i), 48), kv.Value)
 	}
 	for i := 0; i < 4; i++ {
-		kv, ok := iter.Next()
+		kv, ok := iter.Next(context.Background())
 		assert.True(t, ok)
 		assert.Equal(t, repeatedChar(rune('j'+i), 16), kv.Key)
 		assert.Equal(t, repeatedChar(rune('k'+i), 48), kv.Value)
 	}
 
-	next, ok := iter.Next()
+	next, ok := iter.Next(context.Background())
 	assert.False(t, ok)
 	assert.Equal(t, types.KeyValue{}, next)
 }
@@ -92,7 +93,7 @@ func TestShouldWriteManifestSafely(t *testing.T) {
 		l0IDsToCompact = append(l0IDsToCompact, newSourceIDSST(id))
 	}
 
-	db, err = OpenWithOptions(testPath, bucket, options)
+	db, err = OpenWithOptions(context.Background(), testPath, bucket, options)
 	assert.NoError(t, err)
 	db.Put(repeatedChar('j', 32), repeatedChar('k', 96))
 	err = db.Close()
@@ -127,7 +128,7 @@ func TestShouldWriteManifestSafely(t *testing.T) {
 
 func buildTestDB(options DBOptions) (objstore.Bucket, *ManifestStore, *TableStore, *DB) {
 	bucket := objstore.NewInMemBucket()
-	db, err := OpenWithOptions(testPath, bucket, options)
+	db, err := OpenWithOptions(context.Background(), testPath, bucket, options)
 	assert2.True(err == nil, "Failed to open test database")
 	conf := sstable.DefaultConfig()
 	conf.BlockSize = 32

--- a/slatedb/sortedrun.go
+++ b/slatedb/sortedrun.go
@@ -2,6 +2,7 @@ package slatedb
 
 import (
 	"bytes"
+	"context"
 	"github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/sstable"
 	"github.com/slatedb/slatedb-go/internal/types"
@@ -105,9 +106,9 @@ func newSortedRunIter(sstList []sstable.Handle, store *TableStore, fromKey mo.Op
 	}, nil
 }
 
-func (iter *SortedRunIterator) Next() (types.KeyValue, bool) {
+func (iter *SortedRunIterator) Next(ctx context.Context) (types.KeyValue, bool) {
 	for {
-		keyVal, ok := iter.NextEntry()
+		keyVal, ok := iter.NextEntry(ctx)
 		if !ok {
 			return types.KeyValue{}, false
 		}
@@ -122,14 +123,14 @@ func (iter *SortedRunIterator) Next() (types.KeyValue, bool) {
 	}
 }
 
-func (iter *SortedRunIterator) NextEntry() (types.RowEntry, bool) {
+func (iter *SortedRunIterator) NextEntry(ctx context.Context) (types.RowEntry, bool) {
 	for {
 		if iter.currentKVIter.IsAbsent() {
 			return types.RowEntry{}, false
 		}
 
 		kvIter, _ := iter.currentKVIter.Get()
-		kv, ok := kvIter.NextEntry()
+		kv, ok := kvIter.NextEntry(ctx)
 		if ok {
 			return kv, true
 		} else {

--- a/slatedb/sortedrun_test.go
+++ b/slatedb/sortedrun_test.go
@@ -1,6 +1,7 @@
 package slatedb
 
 import (
+	"context"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/mo"
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
@@ -60,7 +61,7 @@ func TestOneSstSRIter(t *testing.T) {
 	assert2.Next(t, iterator, []byte("key2"), []byte("value2"))
 	assert2.Next(t, iterator, []byte("key3"), []byte("value3"))
 
-	kv, ok := iterator.Next()
+	kv, ok := iterator.Next(context.Background())
 	assert.False(t, ok)
 	assert.Equal(t, types.KeyValue{}, kv)
 }
@@ -96,7 +97,7 @@ func TestManySstSRIter(t *testing.T) {
 	assert2.Next(t, iterator, []byte("key2"), []byte("value2"))
 	assert2.Next(t, iterator, []byte("key3"), []byte("value3"))
 
-	kv, ok := iterator.Next()
+	kv, ok := iterator.Next(context.Background())
 	assert.False(t, ok)
 	assert.Equal(t, types.KeyValue{}, kv)
 }
@@ -130,7 +131,7 @@ func TestSRIterFromKey(t *testing.T) {
 		for j := 0; j < 30-i; j++ {
 			assert2.Next(t, kvIter, expectedKeyGen.Next(), expectedValGen.Next())
 		}
-		next, ok := kvIter.Next()
+		next, ok := kvIter.Next(context.Background())
 		assert.False(t, ok)
 		assert.Equal(t, types.KeyValue{}, next)
 	}
@@ -159,7 +160,7 @@ func TestSRIterFromKeyLowerThanRange(t *testing.T) {
 	for j := 0; j < 30; j++ {
 		assert2.Next(t, kvIter, expectedKeyGen.Next(), expectedValGen.Next())
 	}
-	next, ok := kvIter.Next()
+	next, ok := kvIter.Next(context.Background())
 	assert.False(t, ok)
 	assert.Equal(t, types.KeyValue{}, next)
 }
@@ -181,7 +182,7 @@ func TestSRIterFromKeyHigherThanRange(t *testing.T) {
 
 	kvIter, err := newSortedRunIteratorFromKey(sr, []byte("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"), tableStore)
 	assert.NoError(t, err)
-	next, ok := kvIter.Next()
+	next, ok := kvIter.Next(context.Background())
 	assert.False(t, ok)
 	assert.Equal(t, types.KeyValue{}, next)
 }

--- a/slatedb/table_store_test.go
+++ b/slatedb/table_store_test.go
@@ -2,6 +2,7 @@ package slatedb
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"github.com/oklog/ulid/v2"
@@ -75,12 +76,12 @@ func TestBuilderShouldMakeBlocksAvailable(t *testing.T) {
 
 	iterator := nextBlockToIter(t, builder, conf.Compression)
 	assert2.NextEntry(t, iterator, []byte("aaaaaaaa"), []byte("11111111"))
-	_, ok := iterator.NextEntry()
+	_, ok := iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 
 	iterator = nextBlockToIter(t, builder, conf.Compression)
 	assert2.NextEntry(t, iterator, []byte("bbbbbbbb"), []byte("22222222"))
-	_, ok = iterator.NextEntry()
+	_, ok = iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 
 	assert.True(t, builder.NextBlock().IsAbsent())
@@ -88,7 +89,7 @@ func TestBuilderShouldMakeBlocksAvailable(t *testing.T) {
 
 	iterator = nextBlockToIter(t, builder, conf.Compression)
 	assert2.NextEntry(t, iterator, []byte("cccccccc"), []byte("33333333"))
-	_, ok = iterator.NextEntry()
+	_, ok = iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 
 	assert.True(t, builder.NextBlock().IsAbsent())
@@ -130,7 +131,7 @@ func TestBuilderShouldReturnUnconsumedBlocks(t *testing.T) {
 		assert.NoError(t, err)
 		iterator := block.NewIterator(blk)
 		assert2.NextEntry(t, iterator, kv.Key, kv.Value)
-		_, ok := iterator.NextEntry()
+		_, ok := iterator.NextEntry(context.Background())
 		assert.False(t, ok)
 	}
 }
@@ -277,12 +278,12 @@ func TestReadBlocks(t *testing.T) {
 	iterator := block.NewIterator(&blocks[0])
 	assert2.NextEntry(t, iterator, []byte("aa"), []byte("11"))
 	assert2.NextEntry(t, iterator, []byte("bb"), []byte("22"))
-	_, ok := iterator.NextEntry()
+	_, ok := iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 
 	iterator = block.NewIterator(&blocks[1])
 	assert2.NextEntry(t, iterator, []byte("cccccccccccccccccccc"), []byte("33333333333333333333"))
-	_, ok = iterator.NextEntry()
+	_, ok = iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 }
 
@@ -324,17 +325,17 @@ func TestReadAllBlocks(t *testing.T) {
 	iterator := block.NewIterator(&blocks[0])
 	assert2.NextEntry(t, iterator, []byte("aa"), []byte("11"))
 	assert2.NextEntry(t, iterator, []byte("bb"), []byte("22"))
-	_, ok := iterator.NextEntry()
+	_, ok := iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 
 	iterator = block.NewIterator(&blocks[1])
 	assert2.NextEntry(t, iterator, []byte("cccccccccccccccccccc"), []byte("33333333333333333333"))
-	_, ok = iterator.NextEntry()
+	_, ok = iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 
 	iterator = block.NewIterator(&blocks[2])
 	assert2.NextEntry(t, iterator, []byte("dddddddddddddddddddd"), []byte("44444444444444444444"))
-	_, ok = iterator.NextEntry()
+	_, ok = iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 }
 
@@ -369,7 +370,7 @@ func TestOneBlockSSTIter(t *testing.T) {
 	assert2.Next(t, iterator, []byte("key3"), []byte("value3"))
 	assert2.Next(t, iterator, []byte("key4"), []byte("value4"))
 
-	_, ok := iterator.Next()
+	_, ok := iterator.Next(context.Background())
 	assert.False(t, ok)
 }
 
@@ -406,7 +407,7 @@ func TestManyBlockSSTIter(t *testing.T) {
 		}
 	}
 
-	_, ok := iterator.Next()
+	_, ok := iterator.Next(context.Background())
 	assert.False(t, ok)
 }
 
@@ -440,7 +441,7 @@ func TestIterFromKey(t *testing.T) {
 				t.FailNow()
 			}
 		}
-		_, ok := kvIter.Next()
+		_, ok := kvIter.Next(context.Background())
 		assert.False(t, ok)
 	}
 }
@@ -468,7 +469,7 @@ func TestIterFromKeySmallerThanFirst(t *testing.T) {
 	for i := 0; i < nKeys; i++ {
 		assert2.Next(t, kvIter, expectedKeyGen.Next(), expectedValGen.Next())
 	}
-	_, ok := kvIter.Next()
+	_, ok := kvIter.Next(context.Background())
 	assert.False(t, ok)
 }
 
@@ -489,7 +490,7 @@ func TestIterFromKeyLargerThanLast(t *testing.T) {
 	kvIter, err := sstable.NewIteratorAtKey(sst, []byte("zzzzzzzzzzzzzzzz"), tableStore)
 	assert.NoError(t, err)
 
-	_, ok := kvIter.Next()
+	_, ok := kvIter.Next(context.Background())
 	assert.False(t, ok)
 }
 
@@ -559,6 +560,6 @@ func TestSSTWriter(t *testing.T) {
 	assert2.NextEntry(t, iterator, []byte("bbbbbbbbbbbbbbbb"), []byte("2222222222222222"))
 	assert2.NextEntry(t, iterator, []byte("cccccccccccccccc"), nil)
 	assert2.NextEntry(t, iterator, []byte("dddddddddddddddd"), []byte("4444444444444444"))
-	_, ok := iterator.NextEntry()
+	_, ok := iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 }


### PR DESCRIPTION
### Purpose
To support timeout and request cancellation when using iterators which retrieve data from object storage.

### Implementation
- Updated the `KVIterator` interface and all usages 