### PR TITLE
Fix race in compaction

### DIFF
--- a/slatedb/compactor_test.go
+++ b/slatedb/compactor_test.go
@@ -99,8 +99,8 @@ func TestShouldWriteManifestSafely(t *testing.T) {
 
 	err = orchestrator.submitCompaction(newCompaction(l0IDsToCompact, 0))
 	assert.NoError(t, err)
-	orchestrator.executor.waitForTasksCompletion()
-	msg, ok := orchestrator.executor.compactionResult()
+	orchestrator.executor.waitForTasksToComplete()
+	msg, ok := orchestrator.executor.nextCompactionResult()
 	assert.True(t, ok)
 	assert.NotNil(t, msg.SortedRun)
 	sr := msg.SortedRun

--- a/slatedb/compactor_test.go
+++ b/slatedb/compactor_test.go
@@ -101,9 +101,11 @@ func TestShouldWriteManifestSafely(t *testing.T) {
 
 	err = orchestrator.submitCompaction(newCompaction(l0IDsToCompact, 0))
 	assert.NoError(t, err)
-	msg := <-orchestrator.workerCh
-	assert.NotNil(t, msg.CompactionResult)
-	sr := msg.CompactionResult
+	orchestrator.executor.waitForTasksCompletion()
+	msg, ok := orchestrator.executor.compactionResult()
+	assert.True(t, ok)
+	assert.NotNil(t, msg.SortedRun)
+	sr := msg.SortedRun
 
 	err = orchestrator.finishCompaction(sr)
 	assert.NoError(t, err)

--- a/slatedb/compactor_test.go
+++ b/slatedb/compactor_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/slatedb/slatedb-go/slatedb/state"
 	"github.com/slatedb/slatedb-go/slatedb/store"
 	"log/slog"
-	"math"
 	"slices"
 	"testing"
 	"time"
@@ -82,8 +81,7 @@ func TestShouldWriteManifestSafely(t *testing.T) {
 	err = db.Close()
 	assert.NoError(t, err)
 
-	compactorMsgCh := make(chan CompactorMainMsg, math.MaxUint8)
-	orchestrator, err := newCompactorOrchestrator(compactorOptions(), manifestStore, tableStore, compactorMsgCh)
+	orchestrator, err := newCompactorOrchestrator(compactorOptions(), manifestStore, tableStore)
 	assert.NoError(t, err)
 
 	l0IDsToCompact := make([]SourceID, 0)

--- a/slatedb/compactor_test.go
+++ b/slatedb/compactor_test.go
@@ -81,7 +81,7 @@ func TestShouldWriteManifestSafely(t *testing.T) {
 	err = db.Close()
 	assert.NoError(t, err)
 
-	orchestrator, err := newCompactorOrchestrator(compactorOptions(), manifestStore, tableStore)
+	orchestrator, err := newCompactionOrchestrator(compactorOptions(), manifestStore, tableStore)
 	assert.NoError(t, err)
 
 	l0IDsToCompact := make([]SourceID, 0)


### PR DESCRIPTION
Rename CompactorOrchestrator to CompactionOrchestrator

Tried to simplify the implementation by not sharing channels between structs.
compactorMsgCh channel is used to send ShutDown message and is owned by CompactionOrchestrator
resultCh channel is used to hold the Compaction results and is owned by CompactionExecutor