### PR TITLE
Added checksum to SST filter and index block

### DIFF
--- a/internal/sstable/bloom/bloom_test.go
+++ b/internal/sstable/bloom/bloom_test.go
@@ -3,8 +3,10 @@ package bloom
 import (
 	"encoding/binary"
 	"fmt"
+	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/slatedb/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -39,8 +41,10 @@ func TestEncodeDecode(t *testing.T) {
 	fb.Add([]byte("test2"))
 	filter := fb.Build()
 
-	encoded := Encode(filter)
-	decoded := Decode(encoded)
+	encoded, err := Encode(filter, compress.CodecNone)
+	require.NoError(t, err)
+	decoded, err := Decode(encoded, compress.CodecNone)
+	require.NoError(t, err)
 
 	assert.Equal(t, filter.NumProbes, decoded.NumProbes)
 	assert.Equal(t, filter.Data, decoded.Data)

--- a/internal/sstable/builder.go
+++ b/internal/sstable/builder.go
@@ -58,6 +58,8 @@ type Table struct {
 // |  +-----------------------------------------+  |
 // |  |  bloom.Filter (if MinFilterKeys met)    |  |
 // |  +-----------------------------------------+  |
+// |  |  Checksum (4 bytes)                     |  |
+// |  +-----------------------------------------+  |
 // |                                               |
 // |  +-----------------------------------------+  |
 // |  |  flatbuf.SsTableIndexT                  |  |
@@ -65,6 +67,8 @@ type Table struct {
 // |  |  - Block Offset (Start of Block)        |  |
 // |  |  - FirstKey of this Block               |  |
 // |  |  ...                                    |  |
+// |  +-----------------------------------------+  |
+// |  |  Checksum of SsTableIndexT (4 bytes)    |  |
 // |  +-----------------------------------------+  |
 // |                                               |
 // |  +-----------------------------------------+  |
@@ -218,24 +222,23 @@ func (b *Builder) Build() (*Table, error) {
 	filterOffset := b.currentLen + uint64(len(buf))
 	if b.numKeys >= b.conf.MinFilterKeys {
 		filter := b.filterBuilder.Build()
-		compressedFilter, err := compress.Encode(bloom.Encode(filter), b.conf.Compression)
+		encodedFilter, err := bloom.Encode(filter, b.conf.Compression)
 		if err != nil {
 			return nil, err
 		}
-		filterLen = len(compressedFilter)
-		buf = append(buf, compressedFilter...)
+		filterLen = len(encodedFilter)
+		buf = append(buf, encodedFilter...)
 		maybeFilter = mo.Some(filter)
 	}
 
 	// Compress and Write the index block
 	sstIndex := flatbuf.SsTableIndexT{BlockMeta: b.blockMetaList}
-	indexBlock := encodeIndex(sstIndex)
-	compressedIndexBlock, err := compress.Encode(indexBlock, b.conf.Compression)
+	encodedIndex, err := encodeIndex(sstIndex, b.conf.Compression)
 	if err != nil {
 		return nil, err
 	}
 	indexOffset := b.currentLen + uint64(len(buf))
-	buf = append(buf, compressedIndexBlock...)
+	buf = append(buf, encodedIndex...)
 
 	metaOffset := b.currentLen + uint64(len(buf))
 	firstKey, _ := b.firstKey.Get()
@@ -244,7 +247,7 @@ func (b *Builder) Build() (*Table, error) {
 	sstInfo := &Info{
 		FirstKey:         bytes.Clone(firstKey),
 		IndexOffset:      indexOffset,
-		IndexLen:         uint64(len(compressedIndexBlock)),
+		IndexLen:         uint64(len(encodedIndex)),
 		FilterOffset:     filterOffset,
 		FilterLen:        uint64(filterLen),
 		CompressionCodec: b.conf.Compression,

--- a/internal/sstable/decode.go
+++ b/internal/sstable/decode.go
@@ -59,11 +59,12 @@ func ReadFilter(sstInfo *Info, obj common.ReadOnlyBlob) (mo.Option[bloom.Filter]
 		return mo.None[bloom.Filter](), fmt.Errorf("while reading filter offset: %w", err)
 	}
 
-	filterData, err := compress.Decode(filterBytes, sstInfo.CompressionCodec)
+	filterData, err := bloom.Decode(filterBytes, sstInfo.CompressionCodec)
 	if err != nil {
 		return mo.Option[bloom.Filter]{}, err
 	}
-	return mo.Some(bloom.Decode(filterData)), nil
+
+	return mo.Some(filterData), nil
 }
 
 func ReadIndex(info *Info, obj common.ReadOnlyBlob) (*Index, error) {
@@ -75,23 +76,13 @@ func ReadIndex(info *Info, obj common.ReadOnlyBlob) (*Index, error) {
 		return nil, err
 	}
 
-	data, err := compress.Decode(indexBytes, info.CompressionCodec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Index{Data: data}, nil
+	return DecodeIndex(indexBytes, info.CompressionCodec)
 }
 
 func ReadIndexRaw(info *Info, sstBytes []byte) (*Index, error) {
 	indexBytes := sstBytes[info.IndexOffset : info.IndexOffset+info.IndexLen]
 
-	data, err := compress.Decode(indexBytes, info.CompressionCodec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Index{Data: data}, nil
+	return DecodeIndex(indexBytes, info.CompressionCodec)
 }
 
 // getBlockRange returns the (startOffset, endOffset) of the data in ssTable that contains the

--- a/internal/sstable/flatbuf.go
+++ b/internal/sstable/flatbuf.go
@@ -55,8 +55,6 @@ func SstInfoToFlatBuf(info *Info) *flatbuf.SsTableInfoT {
 	}
 }
 
-// TODO(thrawn01): Use these instead of the FlatBufferBuilders above
-
 // EncodeInfo encodes the provided Info into flatbuf.SsTableInfoT flat []byte
 // format along with a checksum of flatbuf.SsTableInfoT
 func EncodeInfo(info *Info) []byte {
@@ -78,6 +76,25 @@ func EncodeInfo(info *Info) []byte {
 
 	// Add a checksum to the end of the slice
 	return binary.BigEndian.AppendUint32(b, crc32.ChecksumIEEE(b))
+}
+
+func DecodeIndex(buf []byte, codec compress.Codec) (*Index, error) {
+	if len(buf) <= common.SizeOfUint32 {
+		return nil, common.ErrEmptyBlockMeta
+	}
+
+	checksumIndex := len(buf) - common.SizeOfUint32
+	compressed := buf[:checksumIndex]
+	if binary.BigEndian.Uint32(buf[checksumIndex:]) != crc32.ChecksumIEEE(compressed) {
+		return nil, common.ErrChecksumMismatch
+	}
+
+	buf, err := compress.Decode(compressed, codec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Index{Data: buf}, nil
 }
 
 func DecodeInfo(b []byte) (*Info, error) {
@@ -104,11 +121,19 @@ func DecodeInfo(b []byte) (*Info, error) {
 	return info, nil
 }
 
-func encodeIndex(index flatbuf.SsTableIndexT) []byte {
+func encodeIndex(index flatbuf.SsTableIndexT, codec compress.Codec) ([]byte, error) {
 	builder := flatbuffers.NewBuilder(0)
 	offset := index.Pack(builder)
 	builder.Finish(offset)
-	return builder.FinishedBytes()
+
+	compressed, err := compress.Encode(builder.FinishedBytes(), codec)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 0, len(compressed)+common.SizeOfUint32)
+	buf = append(buf, compressed...)
+	return binary.BigEndian.AppendUint32(buf, crc32.ChecksumIEEE(compressed)), nil
 }
 
 // EncodeTable encodes the provided sstable.Table into the

--- a/slatedb/store/table_store_test.go
+++ b/slatedb/store/table_store_test.go
@@ -209,9 +209,11 @@ func TestSSTableBuildsFilterWithCorrectBitsPerKey(t *testing.T) {
 		encodedSST, err := builder.Build()
 		assert.NoError(t, err)
 		filter, _ := encodedSST.Bloom.Get()
-		// filters are encoded as a 2 byte number of probes followed by the filter
+		// filters are encoded as a 2 byte number of probes followed by the filter + 4 byte checksum
 		// Since we have added 8 keys, the filter will have (8 * FilterBitsPerKey) bits or FilterBitsPerKey bytes
-		assert.Equal(t, 2+int(filterBitsPerKey), len(bloom.Encode(filter)))
+		f, err := bloom.Encode(filter, compress.CodecNone)
+		assert.NoError(t, err)
+		assert.Equal(t, 2+int(filterBitsPerKey)+4, len(f))
 	}
 }
 


### PR DESCRIPTION
### Purpose
To [add checksums to both filter and index block]( https://github.com/slatedb/slatedb/pull/412 ) and to add some additional corruption checks discovered while working on https://github.com/slatedb/slatedb/pull/411

### Implementation
- Added some tests for block corruption
- Discovered one corruption check is unreachable, changed it to an assertion
- Moved compression and checksum of index into `DecodeIndex()` and `encodeIndex()`
- Moved compression and checksum of filter into `bloom.Decode()` and `bloom.Encode()`
