### PR TITLE
add goimports to golangci-lint to sort imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+linters:
+  enable:
+    - goimports
+linters-settings:
+  goimports:
+    local-prefixes: github.com/slatedb/slatedb-go

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ $(LINT): ## Download Go linter
 lint: $(LINT) ## Run Go linter
 	$(LINT) run -v ./...
 
+format_imports:
+	go install golang.org/x/tools/cmd/goimports@latest
+	goimports -l -w .
+
 fmt:
 	go fmt ./...
 
@@ -20,7 +24,7 @@ flatbuf:
 	go fmt ./internal/flatbuf/*.go
 
 .PHONY: build
-build: flatbuf fmt vet
+build: flatbuf fmt vet format_imports
 	go build -v -o bin/slatedb -race ./cmd
 
 test_coverage:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LINT = $(GOPATH)/bin/golangci-lint
 LINT_VERSION = v1.61.0
 
 $(LINT): ## Download Go linter
-        curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(LINT_VERSION)
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(LINT_VERSION)
 
 .PHONY: lint
 lint: $(LINT) ## Run Go linter

--- a/README.md
+++ b/README.md
@@ -23,14 +23,12 @@ package main
 
 import (
    "context"
-   "errors"
+   "fmt"
    "log/slog"
    "time"
 
-   "github.com/thanos-io/objstore"
-
    "github.com/slatedb/slatedb-go/slatedb"
-   "github.com/slatedb/slatedb-go/slatedb/common"
+   "github.com/thanos-io/objstore"
 )
 
 func main() {
@@ -43,21 +41,21 @@ func main() {
    value := []byte("value1")
 
    db.Put(key, value)
-   slog.With("key", string(key)).With("value", string(value)).Info("Put into slatedb")
+   fmt.Println("Put:", string(key), string(value))
 
    data, _ := db.Get(ctx, key)
-   slog.With("key", string(key)).With("value", string(data)).Info("Get from slatedb")
+   fmt.Println("Get:", string(key), string(data))
 
    db.Delete(key)
    _, err := db.Get(ctx, key)
-   if errors.Is(err, common.ErrKeyNotFound) {
-      slog.With("key", string(key)).Info("Key deleted")
+   if err != nil && err.Error() == "key not found" {
+      fmt.Println("Delete:", string(key))
    } else {
-      slog.With("err", err).Error("Unable to delete")
+      slog.Error("Unable to delete", "error", err)
    }
 
    if err := db.Close(); err != nil {
-      slog.With("err", err).Error("Error closing db")
+      slog.Error("Error closing db", "error", err)
    }
 }
 ```
@@ -74,11 +72,11 @@ SlateDB is licensed under the Apache License, Version 2.0.
 
 1. Why is there a Go port instead of using Go binding ?
 
-    We wanted developers using this library in Go to be able to easily understand and modify(if needed) the internals without having to learn a new language.
+   We wanted developers using this library in Go to be able to easily understand and modify(if needed) the internals without having to learn a new language.
 
-    Go developers will also have an option to use Go binding(when it is ready) if they can use cgo/ffi.
+   Go developers will also have an option to use Go binding(when it is ready) if they can use cgo/ffi.
 
 
 2. Is there a risk of a drift between the inner workings of the Rust and Go implementation?
 
-    We will try to keep it close to the Rust implementation.
+   We will try to keep it close to the Rust implementation.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ package main
 
 import (
    "context"
-   "fmt"
+   "errors"
    "log/slog"
    "time"
 
-   "github.com/slatedb/slatedb-go/slatedb"
    "github.com/thanos-io/objstore"
+
+   "github.com/slatedb/slatedb-go/slatedb"
+   "github.com/slatedb/slatedb-go/slatedb/common"
 )
 
 func main() {
@@ -41,21 +43,21 @@ func main() {
    value := []byte("value1")
 
    db.Put(key, value)
-   fmt.Println("Put:", string(key), string(value))
+   slog.With("key", string(key)).With("value", string(value)).Info("Put into slatedb")
 
    data, _ := db.Get(ctx, key)
-   fmt.Println("Get:", string(key), string(data))
+   slog.With("key", string(key)).With("value", string(data)).Info("Get from slatedb")
 
    db.Delete(key)
    _, err := db.Get(ctx, key)
-   if err != nil && err.Error() == "key not found" {
-      fmt.Println("Delete:", string(key))
+   if errors.Is(err, common.ErrKeyNotFound) {
+      slog.With("key", string(key)).Info("Key deleted")
    } else {
-      slog.Error("Unable to delete", "error", err)
+      slog.With("err", err).Error("Unable to delete")
    }
 
    if err := db.Close(); err != nil {
-      slog.Error("Error closing db", "error", err)
+      slog.With("err", err).Error("Error closing db")
    }
 }
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,8 +6,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/slatedb/slatedb-go/slatedb"
 	"github.com/thanos-io/objstore"
+
+	"github.com/slatedb/slatedb-go/slatedb"
 )
 
 func main() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,7 +22,7 @@ func main() {
 	value := []byte("value1")
 
 	db.Put(key, value)
-	slog.With("key", string(key)).Info("Put into slatedb")
+	slog.With("key", string(key)).With("value", string(value)).Info("Put into slatedb")
 
 	data, _ := db.Get(ctx, key)
 	slog.With("key", string(key)).With("value", string(data)).Info("Get from slatedb")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/slatedb/slatedb-go
 
-go 1.23.1
+go 1.23
 
 require (
 	github.com/gammazero/deque v0.2.1

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -3,9 +3,11 @@ package assert
 import (
 	"context"
 	"fmt"
-	"github.com/slatedb/slatedb-go/internal/iter"
-	assert2 "github.com/stretchr/testify/assert"
 	"testing"
+
+	assert2 "github.com/stretchr/testify/assert"
+
+	"github.com/slatedb/slatedb-go/internal/iter"
 )
 
 func True(condition bool, errMsg string, arg ...any) {

--- a/internal/compress/compression.go
+++ b/internal/compress/compression.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"compress/zlib"
 	"errors"
+	"io"
+
 	"github.com/golang/snappy"
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
+
 	"github.com/slatedb/slatedb-go/internal/flatbuf"
-	"io"
 )
 
 const (

--- a/internal/flatbuf/manifest_generated.go
+++ b/internal/flatbuf/manifest_generated.go
@@ -3,8 +3,9 @@
 package flatbuf
 
 import (
-	flatbuffers "github.com/google/flatbuffers/go"
 	"strconv"
+
+	flatbuffers "github.com/google/flatbuffers/go"
 )
 
 type CompressionCodec int8

--- a/internal/iter/entry.go
+++ b/internal/iter/entry.go
@@ -2,6 +2,7 @@ package iter
 
 import (
 	"context"
+
 	"github.com/slatedb/slatedb-go/internal/types"
 )
 

--- a/internal/iter/entry_test.go
+++ b/internal/iter/entry_test.go
@@ -2,9 +2,11 @@ package iter_test
 
 import (
 	"context"
-	"github.com/slatedb/slatedb-go/internal/iter"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/slatedb/slatedb-go/internal/iter"
 )
 
 func TestNewEntryIterator(t *testing.T) {

--- a/internal/iter/merge.go
+++ b/internal/iter/merge.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 	"container/heap"
 	"context"
+
 	"github.com/slatedb/slatedb-go/internal/types"
 )
 

--- a/internal/iter/merge_test.go
+++ b/internal/iter/merge_test.go
@@ -2,10 +2,12 @@ package iter_test
 
 import (
 	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/iter"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestMergeUniqueIteratorPrecedence(t *testing.T) {

--- a/internal/sstable/blob.go
+++ b/internal/sstable/blob.go
@@ -2,6 +2,7 @@ package sstable
 
 import (
 	"errors"
+
 	"github.com/slatedb/slatedb-go/slatedb/common"
 )
 

--- a/internal/sstable/block/block.go
+++ b/internal/sstable/block/block.go
@@ -6,11 +6,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash/crc32"
+
 	"github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/types"
 	"github.com/slatedb/slatedb-go/slatedb/common"
-	"hash/crc32"
 )
 
 var (

--- a/internal/sstable/block/block_test.go
+++ b/internal/sstable/block/block_test.go
@@ -4,15 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"hash/crc32"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/sstable/block"
 	"github.com/slatedb/slatedb-go/internal/types"
 	"github.com/slatedb/slatedb-go/slatedb/common"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"hash/crc32"
-	"testing"
 )
 
 func TestNewBuilder(t *testing.T) {

--- a/internal/sstable/block/iterator.go
+++ b/internal/sstable/block/iterator.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/slatedb/slatedb-go/internal/types"
 	"sort"
+
+	"github.com/slatedb/slatedb-go/internal/types"
 )
 
 // Iterator iterates through KeyValue pairs present in the Block.

--- a/internal/sstable/block/row.go
+++ b/internal/sstable/block/row.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"math"
+	"time"
+
 	"github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/types"
 	"github.com/slatedb/slatedb-go/slatedb/common"
-	"math"
-	"time"
 )
 
 var v0RowCodec v0Codec

--- a/internal/sstable/block/row_test.go
+++ b/internal/sstable/block/row_test.go
@@ -2,13 +2,15 @@ package block
 
 import (
 	"bytes"
-	"github.com/kapetan-io/tackle/random"
-	"github.com/slatedb/slatedb-go/internal/compress"
-	"github.com/slatedb/slatedb-go/internal/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/kapetan-io/tackle/random"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/slatedb/slatedb-go/internal/compress"
+	"github.com/slatedb/slatedb-go/internal/types"
 )
 
 func TestRowFlags(t *testing.T) {

--- a/internal/sstable/bloom/bloom.go
+++ b/internal/sstable/bloom/bloom.go
@@ -3,10 +3,11 @@ package bloom
 import (
 	"encoding/binary"
 	"errors"
-	"github.com/slatedb/slatedb-go/internal/compress"
-	"github.com/slatedb/slatedb-go/slatedb/common"
 	"hash/crc32"
 	"hash/fnv"
+
+	"github.com/slatedb/slatedb-go/internal/compress"
+	"github.com/slatedb/slatedb-go/slatedb/common"
 )
 
 type Filter struct {

--- a/internal/sstable/bloom/bloom_test.go
+++ b/internal/sstable/bloom/bloom_test.go
@@ -3,11 +3,13 @@ package bloom
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/slatedb/slatedb-go/internal/compress"
-	"github.com/slatedb/slatedb-go/slatedb/common"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/slatedb/slatedb-go/internal/compress"
+	"github.com/slatedb/slatedb-go/slatedb/common"
 )
 
 func TestFilterBuilder_Build(t *testing.T) {

--- a/internal/sstable/builder.go
+++ b/internal/sstable/builder.go
@@ -3,8 +3,10 @@ package sstable
 import (
 	"bytes"
 	"encoding/binary"
+
 	"github.com/gammazero/deque"
 	"github.com/samber/mo"
+
 	"github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/flatbuf"

--- a/internal/sstable/builder_test.go
+++ b/internal/sstable/builder_test.go
@@ -2,15 +2,17 @@ package sstable_test
 
 import (
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/sstable"
 	"github.com/slatedb/slatedb-go/internal/sstable/block"
 	"github.com/slatedb/slatedb-go/internal/types"
 	"github.com/slatedb/slatedb-go/slatedb/common"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestBuilder(t *testing.T) {

--- a/internal/sstable/decode.go
+++ b/internal/sstable/decode.go
@@ -3,7 +3,9 @@ package sstable
 import (
 	"encoding/binary"
 	"fmt"
+
 	"github.com/samber/mo"
+
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/sstable/block"
 	"github.com/slatedb/slatedb-go/internal/sstable/bloom"

--- a/internal/sstable/flatbuf.go
+++ b/internal/sstable/flatbuf.go
@@ -3,11 +3,13 @@ package sstable
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/google/flatbuffers/go"
+	"hash/crc32"
+
+	flatbuffers "github.com/google/flatbuffers/go"
+
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/flatbuf"
 	"github.com/slatedb/slatedb-go/slatedb/common"
-	"hash/crc32"
 )
 
 type Index struct {

--- a/internal/sstable/iterator.go
+++ b/internal/sstable/iterator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/slatedb/slatedb-go/internal/sstable/block"
 	"github.com/slatedb/slatedb-go/internal/types"
 	"github.com/slatedb/slatedb-go/slatedb/common"

--- a/internal/sstable/pretty.go
+++ b/internal/sstable/pretty.go
@@ -3,8 +3,9 @@ package sstable
 import (
 	"bytes"
 	"fmt"
-	"github.com/slatedb/slatedb-go/internal/sstable/block"
 	"strings"
+
+	"github.com/slatedb/slatedb-go/internal/sstable/block"
 )
 
 // PrettyPrint returns a string representation of the SSTable in a human-readable format

--- a/internal/sstable/pretty_test.go
+++ b/internal/sstable/pretty_test.go
@@ -1,9 +1,11 @@
 package sstable
 
 import (
-	"github.com/slatedb/slatedb-go/internal/compress"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/slatedb/slatedb-go/internal/compress"
 )
 
 func TestPrettyPrint(t *testing.T) {

--- a/internal/sstable/sstable.go
+++ b/internal/sstable/sstable.go
@@ -2,6 +2,7 @@ package sstable
 
 import (
 	"bytes"
+
 	"github.com/slatedb/slatedb-go/internal/compress"
 )
 

--- a/internal/sstable/sstable_test.go
+++ b/internal/sstable/sstable_test.go
@@ -2,11 +2,13 @@ package sstable_test
 
 import (
 	"bytes"
-	"github.com/slatedb/slatedb-go/internal/compress"
-	"github.com/slatedb/slatedb-go/internal/sstable"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/slatedb/slatedb-go/internal/compress"
+	"github.com/slatedb/slatedb-go/internal/sstable"
 )
 
 func TestInfoClone(t *testing.T) {

--- a/internal/sstable/table.go
+++ b/internal/sstable/table.go
@@ -3,10 +3,11 @@ package sstable
 import (
 	"bytes"
 	"fmt"
-	"github.com/oklog/ulid/v2"
-	"github.com/samber/mo"
 	"log/slog"
 	"strconv"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/mo"
 )
 
 type IDType int

--- a/internal/types/errors_test.go
+++ b/internal/types/errors_test.go
@@ -3,9 +3,11 @@ package types_test
 import (
 	"errors"
 	"fmt"
-	"github.com/slatedb/slatedb-go/internal/types"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/slatedb/slatedb-go/internal/types"
 )
 
 func TestErrWarn(t *testing.T) {

--- a/slatedb/compaction/sortedrun.go
+++ b/slatedb/compaction/sortedrun.go
@@ -3,11 +3,13 @@ package compaction
 import (
 	"bytes"
 	"context"
+	"sort"
+
 	"github.com/samber/mo"
+
 	"github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/sstable"
 	"github.com/slatedb/slatedb-go/internal/types"
-	"sort"
 )
 
 // ------------------------------------------------

--- a/slatedb/compactor.go
+++ b/slatedb/compactor.go
@@ -3,7 +3,13 @@ package slatedb
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/oklog/ulid/v2"
+
 	"github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/iter"
 	"github.com/slatedb/slatedb-go/internal/sstable"
@@ -12,10 +18,6 @@ import (
 	compaction2 "github.com/slatedb/slatedb-go/slatedb/compaction"
 	"github.com/slatedb/slatedb-go/slatedb/config"
 	"github.com/slatedb/slatedb-go/slatedb/store"
-	"log/slog"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 type CompactionScheduler interface {

--- a/slatedb/compactor_state.go
+++ b/slatedb/compactor_state.go
@@ -1,17 +1,20 @@
 package slatedb
 
 import (
-	"github.com/kapetan-io/tackle/set"
-	"github.com/slatedb/slatedb-go/internal/assert"
-	"github.com/slatedb/slatedb-go/internal/sstable"
-	compaction2 "github.com/slatedb/slatedb-go/slatedb/compaction"
-	"github.com/slatedb/slatedb-go/slatedb/state"
 	"log/slog"
 	"math"
 	"strconv"
 
+	"github.com/kapetan-io/tackle/set"
+
+	"github.com/slatedb/slatedb-go/internal/assert"
+	"github.com/slatedb/slatedb-go/internal/sstable"
+	compaction2 "github.com/slatedb/slatedb-go/slatedb/compaction"
+	"github.com/slatedb/slatedb-go/slatedb/state"
+
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/mo"
+
 	"github.com/slatedb/slatedb-go/slatedb/common"
 )
 

--- a/slatedb/compactor_state_test.go
+++ b/slatedb/compactor_state_test.go
@@ -2,17 +2,19 @@ package slatedb
 
 import (
 	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/sstable"
 	compaction2 "github.com/slatedb/slatedb-go/slatedb/compaction"
 	"github.com/slatedb/slatedb-go/slatedb/config"
 	"github.com/slatedb/slatedb-go/slatedb/state"
 	"github.com/slatedb/slatedb-go/slatedb/store"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/objstore"
-	"testing"
-	"time"
 )
 
 var testPath = "/test/db"

--- a/slatedb/compactor_test.go
+++ b/slatedb/compactor_test.go
@@ -2,6 +2,11 @@ package slatedb
 
 import (
 	"context"
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/sstable"
@@ -9,10 +14,6 @@ import (
 	"github.com/slatedb/slatedb-go/slatedb/config"
 	"github.com/slatedb/slatedb-go/slatedb/state"
 	"github.com/slatedb/slatedb-go/slatedb/store"
-	"log/slog"
-	"slices"
-	"testing"
-	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/mo"

--- a/slatedb/config/config.go
+++ b/slatedb/config/config.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"github.com/slatedb/slatedb-go/internal/compress"
 	"log/slog"
 	"time"
+
+	"github.com/slatedb/slatedb-go/internal/compress"
 )
 
 // DBOptions Configuration opts for the database. These opts are set on client startup.

--- a/slatedb/db.go
+++ b/slatedb/db.go
@@ -5,7 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"math"
+	"sync"
+
 	"github.com/kapetan-io/tackle/set"
+
 	"github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/sstable"
 	"github.com/slatedb/slatedb-go/internal/types"
@@ -13,12 +18,10 @@ import (
 	"github.com/slatedb/slatedb-go/slatedb/config"
 	"github.com/slatedb/slatedb-go/slatedb/state"
 	"github.com/slatedb/slatedb-go/slatedb/store"
-	"log/slog"
-	"math"
-	"sync"
+
+	"github.com/thanos-io/objstore"
 
 	"github.com/slatedb/slatedb-go/slatedb/common"
-	"github.com/thanos-io/objstore"
 )
 
 const BlockSize = 4096

--- a/slatedb/db_test.go
+++ b/slatedb/db_test.go
@@ -3,6 +3,14 @@ package slatedb
 import (
 	"bytes"
 	"context"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/sstable"
@@ -10,16 +18,11 @@ import (
 	"github.com/slatedb/slatedb-go/slatedb/config"
 	"github.com/slatedb/slatedb-go/slatedb/state"
 	"github.com/slatedb/slatedb-go/slatedb/store"
-	"github.com/stretchr/testify/require"
-	"math"
-	"strconv"
-	"strings"
-	"testing"
-	"time"
 
-	"github.com/slatedb/slatedb-go/slatedb/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/thanos-io/objstore"
+
+	"github.com/slatedb/slatedb-go/slatedb/common"
 )
 
 // TODO: Look into injecting failpoints

--- a/slatedb/flush.go
+++ b/slatedb/flush.go
@@ -2,14 +2,16 @@ package slatedb
 
 import (
 	"errors"
-	"github.com/slatedb/slatedb-go/internal/sstable"
-	"github.com/slatedb/slatedb-go/slatedb/store"
-	"github.com/slatedb/slatedb-go/slatedb/table"
 	"log/slog"
 	"sync"
 	"time"
 
+	"github.com/slatedb/slatedb-go/internal/sstable"
+	"github.com/slatedb/slatedb-go/slatedb/store"
+	"github.com/slatedb/slatedb-go/slatedb/table"
+
 	"github.com/oklog/ulid/v2"
+
 	"github.com/slatedb/slatedb-go/slatedb/common"
 )
 

--- a/slatedb/manifest/codec.go
+++ b/slatedb/manifest/codec.go
@@ -3,9 +3,11 @@ package manifest
 import (
 	"bytes"
 	"encoding/binary"
+
 	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/mo"
+
 	"github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/flatbuf"

--- a/slatedb/manifest/manifest.go
+++ b/slatedb/manifest/manifest.go
@@ -1,8 +1,9 @@
 package manifest
 
 import (
-	"github.com/slatedb/slatedb-go/slatedb/state"
 	"sync/atomic"
+
+	"github.com/slatedb/slatedb-go/slatedb/state"
 )
 
 type Manifest struct {

--- a/slatedb/sortedrun_test.go
+++ b/slatedb/sortedrun_test.go
@@ -2,18 +2,20 @@ package slatedb
 
 import (
 	"context"
+	"testing"
+
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/mo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/sstable"
 	"github.com/slatedb/slatedb-go/internal/types"
 	"github.com/slatedb/slatedb-go/slatedb/common"
 	"github.com/slatedb/slatedb-go/slatedb/compaction"
 	"github.com/slatedb/slatedb-go/slatedb/store"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/objstore"
-	"testing"
 )
 
 func buildSRWithSSTs(

--- a/slatedb/state/db_state.go
+++ b/slatedb/state/db_state.go
@@ -1,17 +1,19 @@
 package state
 
 import (
-	"github.com/slatedb/slatedb-go/internal/assert"
-	"github.com/slatedb/slatedb-go/internal/sstable"
-	"github.com/slatedb/slatedb-go/slatedb/compaction"
-	"github.com/slatedb/slatedb-go/slatedb/table"
 	"log/slog"
 	"sync"
 	"sync/atomic"
 
+	"github.com/slatedb/slatedb-go/internal/assert"
+	"github.com/slatedb/slatedb-go/internal/sstable"
+	"github.com/slatedb/slatedb-go/slatedb/compaction"
+	"github.com/slatedb/slatedb-go/slatedb/table"
+
 	"github.com/gammazero/deque"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/mo"
+
 	"github.com/slatedb/slatedb-go/slatedb/common"
 )
 

--- a/slatedb/state/db_state_test.go
+++ b/slatedb/state/db_state_test.go
@@ -1,12 +1,14 @@
 package state
 
 import (
+	"testing"
+
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/mo"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/sstable"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func addL0sToDBState(dbState *DBState, n uint32) {

--- a/slatedb/store/manifest_store.go
+++ b/slatedb/store/manifest_store.go
@@ -4,17 +4,19 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
-	"github.com/samber/mo"
-	"github.com/slatedb/slatedb-go/slatedb/common"
-	"github.com/slatedb/slatedb-go/slatedb/manifest"
-	"github.com/slatedb/slatedb-go/slatedb/state"
-	"github.com/thanos-io/objstore"
 	"path"
 	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/samber/mo"
+	"github.com/thanos-io/objstore"
+
+	"github.com/slatedb/slatedb-go/slatedb/common"
+	"github.com/slatedb/slatedb-go/slatedb/manifest"
+	"github.com/slatedb/slatedb-go/slatedb/state"
 )
 
 const manifestDir = "manifest"

--- a/slatedb/store/manifest_store_test.go
+++ b/slatedb/store/manifest_store_test.go
@@ -1,11 +1,13 @@
 package store
 
 import (
-	"github.com/slatedb/slatedb-go/slatedb/common"
-	"github.com/slatedb/slatedb-go/slatedb/state"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thanos-io/objstore"
-	"testing"
+
+	"github.com/slatedb/slatedb-go/slatedb/common"
+	"github.com/slatedb/slatedb-go/slatedb/state"
 )
 
 func TestShouldFailWriteOnVersionConflict(t *testing.T) {

--- a/slatedb/store/object_store.go
+++ b/slatedb/store/object_store.go
@@ -10,8 +10,9 @@ import (
 	"time"
 
 	"github.com/samber/mo"
-	"github.com/slatedb/slatedb-go/slatedb/common"
 	"github.com/thanos-io/objstore"
+
+	"github.com/slatedb/slatedb-go/slatedb/common"
 )
 
 type ObjectMeta struct {

--- a/slatedb/store/object_store_test.go
+++ b/slatedb/store/object_store_test.go
@@ -3,14 +3,16 @@ package store
 import (
 	"bytes"
 	"context"
-	"github.com/samber/mo"
-	"github.com/slatedb/slatedb-go/slatedb/common"
-	"github.com/stretchr/testify/assert"
-	"github.com/thanos-io/objstore"
 	"io"
 	"path"
 	"sort"
 	"testing"
+
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/assert"
+	"github.com/thanos-io/objstore"
+
+	"github.com/slatedb/slatedb-go/slatedb/common"
 )
 
 var rootPath = "/root/path"

--- a/slatedb/store/table_store.go
+++ b/slatedb/store/table_store.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/slatedb/slatedb-go/internal/assert"
 	"io"
 	"path"
 	"slices"
@@ -12,13 +11,16 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/slatedb/slatedb-go/internal/assert"
+
 	"github.com/maypok86/otter"
 	"github.com/samber/mo"
+	"github.com/thanos-io/objstore"
+
 	"github.com/slatedb/slatedb-go/internal/sstable"
 	"github.com/slatedb/slatedb-go/internal/sstable/block"
 	"github.com/slatedb/slatedb-go/internal/sstable/bloom"
 	"github.com/slatedb/slatedb-go/slatedb/common"
-	"github.com/thanos-io/objstore"
 )
 
 // ------------------------------------------------

--- a/slatedb/store/table_store_test.go
+++ b/slatedb/store/table_store_test.go
@@ -5,8 +5,15 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/mo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
 	assert2 "github.com/slatedb/slatedb-go/internal/assert"
 	"github.com/slatedb/slatedb-go/internal/compress"
 	"github.com/slatedb/slatedb-go/internal/sstable"
@@ -14,11 +21,6 @@ import (
 	"github.com/slatedb/slatedb-go/internal/sstable/bloom"
 	"github.com/slatedb/slatedb-go/internal/types"
 	"github.com/slatedb/slatedb-go/slatedb/common"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/objstore"
-	"strconv"
-	"testing"
 )
 
 type BytesBlob struct {

--- a/slatedb/table/kvtable.go
+++ b/slatedb/table/kvtable.go
@@ -1,10 +1,12 @@
 package table
 
 import (
+	"sync/atomic"
+
 	"github.com/huandu/skiplist"
 	"github.com/samber/mo"
+
 	"github.com/slatedb/slatedb-go/internal/types"
-	"sync/atomic"
 )
 
 // ------------------------------------------------

--- a/slatedb/table/memtable.go
+++ b/slatedb/table/memtable.go
@@ -1,9 +1,11 @@
 package table
 
 import (
-	"github.com/samber/mo"
-	"github.com/slatedb/slatedb-go/internal/types"
 	"sync"
+
+	"github.com/samber/mo"
+
+	"github.com/slatedb/slatedb-go/internal/types"
 )
 
 // ------------------------------------------------

--- a/slatedb/table/memtable_test.go
+++ b/slatedb/table/memtable_test.go
@@ -2,9 +2,11 @@ package table
 
 import (
 	"bytes"
-	"github.com/slatedb/slatedb-go/internal/types"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/slatedb/slatedb-go/internal/types"
 )
 
 func TestMemtableOps(t *testing.T) {

--- a/slatedb/table/wal.go
+++ b/slatedb/table/wal.go
@@ -1,9 +1,11 @@
 package table
 
 import (
-	"github.com/samber/mo"
-	"github.com/slatedb/slatedb-go/internal/types"
 	"sync"
+
+	"github.com/samber/mo"
+
+	"github.com/slatedb/slatedb-go/internal/types"
 )
 
 // ------------------------------------------------

--- a/slatedb/table/wal_test.go
+++ b/slatedb/table/wal_test.go
@@ -2,9 +2,11 @@ package table
 
 import (
 	"bytes"
-	"github.com/slatedb/slatedb-go/internal/types"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/slatedb/slatedb-go/internal/types"
 )
 
 func TestWALOps(t *testing.T) {


### PR DESCRIPTION
This PR introduces `goimports` to the `golangci-lint` configuration to automatically sort imports according to the Go community's standard conventions. It also `fmt.Println` to `slog` for consistency in `cmd/main.go`.
