### PR TITLE
Added context.Context to public methods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,13 +21,13 @@ func main() {
 	key := []byte("key1")
 	value := []byte("value1")
 
-	db.Put(key, value)
+	_ = db.Put(ctx, key, value)
 	fmt.Println("Put:", string(key), string(value))
 
 	data, _ := db.Get(ctx, key)
 	fmt.Println("Get:", string(key), string(data))
 
-	db.Delete(key)
+	_ = db.Delete(ctx, key)
 	_, err := db.Get(ctx, key)
 	if err != nil && err.Error() == "key not found" {
 		fmt.Println("Delete:", string(key))
@@ -35,7 +35,7 @@ func main() {
 		slog.Error("Unable to delete", "error", err)
 	}
 
-	if err := db.Close(); err != nil {
+	if err := db.Close(ctx); err != nil {
 		slog.Error("Error closing db", "error", err)
 	}
 }

--- a/internal/sstable/blob.go
+++ b/internal/sstable/blob.go
@@ -1,6 +1,7 @@
 package sstable
 
 import (
+	"context"
 	"errors"
 
 	"github.com/slatedb/slatedb-go/slatedb/common"
@@ -15,17 +16,17 @@ type bytesBlob struct {
 	data []byte
 }
 
-func (b *bytesBlob) Len() (int, error) {
+func (b *bytesBlob) Len(_ context.Context) (int, error) {
 	return len(b.data), nil
 }
 
-func (b *bytesBlob) ReadRange(r common.Range) ([]byte, error) {
+func (b *bytesBlob) ReadRange(_ context.Context, r common.Range) ([]byte, error) {
 	if r.Start > uint64(len(b.data)) || r.End > uint64(len(b.data)) || r.Start > r.End {
 		return nil, errors.New("invalid range")
 	}
 	return b.data[r.Start:r.End], nil
 }
 
-func (b *bytesBlob) Read() ([]byte, error) {
+func (b *bytesBlob) Read(_ context.Context) ([]byte, error) {
 	return b.data, nil
 }

--- a/internal/sstable/builder_test.go
+++ b/internal/sstable/builder_test.go
@@ -1,6 +1,7 @@
 package sstable_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -95,7 +96,7 @@ func TestBuilder(t *testing.T) {
 }
 
 func TestEncodeDecode(t *testing.T) {
-
+	ctx := context.Background()
 	input := [][]types.KeyValue{
 		{types.KeyValue{Key: []byte("key1"), Value: []byte("value1")}},
 		{types.KeyValue{Key: []byte("key2"), Value: []byte("value2")}},
@@ -125,7 +126,7 @@ func TestEncodeDecode(t *testing.T) {
 	blob := sstable.NewBytesBlob(encoded)
 
 	// Decode the Info from the table
-	info, err := sstable.ReadInfo(blob)
+	info, err := sstable.ReadInfo(ctx, blob)
 	assert.NoError(t, err)
 	assert.NotNil(t, info)
 	assert.Equal(t, table.Info.FirstKey, info.FirstKey)
@@ -133,12 +134,12 @@ func TestEncodeDecode(t *testing.T) {
 	assert.Equal(t, table.Info.IndexLen, info.IndexLen)
 
 	// Decode the index from the table
-	index, err := sstable.ReadIndex(info, blob)
+	index, err := sstable.ReadIndex(ctx, info, blob)
 	assert.NoError(t, err)
 	assert.NotNil(t, index)
 
 	// Read the first block from the table
-	blocks, err := sstable.ReadBlocks(info, index, common.Range{Start: 0, End: 3}, blob)
+	blocks, err := sstable.ReadBlocks(ctx, info, index, common.Range{Start: 0, End: 3}, blob)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(input))
 
@@ -153,7 +154,7 @@ func TestEncodeDecode(t *testing.T) {
 	assert2.NextEntry(t, it, []byte("key3"), []byte("value3"))
 
 	// Test bloom filter
-	filter, err := sstable.ReadFilter(info, blob)
+	filter, err := sstable.ReadFilter(ctx, info, blob)
 	assert.NoError(t, err)
 	assert.True(t, filter.IsPresent())
 	f, ok := filter.Get()

--- a/slatedb/common/blob.go
+++ b/slatedb/common/blob.go
@@ -1,7 +1,9 @@
 package common
 
+import "context"
+
 type ReadOnlyBlob interface {
-	Len() (int, error)
-	ReadRange(r Range) ([]byte, error)
-	Read() ([]byte, error)
+	Len(ctx context.Context) (int, error)
+	ReadRange(ctx context.Context, r Range) ([]byte, error)
+	Read(ctx context.Context) ([]byte, error)
 }

--- a/slatedb/compaction/compactor.go
+++ b/slatedb/compaction/compactor.go
@@ -1,6 +1,7 @@
 package compaction
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/oklog/ulid/v2"
@@ -114,8 +115,8 @@ func NewCompactor(manifestStore *store.ManifestStore, tableStore *store.TableSto
 	}, nil
 }
 
-func (c *Compactor) Close() {
-	c.orchestrator.shutdown()
+func (c *Compactor) Close(ctx context.Context) error {
+	return c.orchestrator.shutdown(ctx)
 }
 
 func spawnAndRunCompactionOrchestrator(

--- a/slatedb/config/config.go
+++ b/slatedb/config/config.go
@@ -134,6 +134,10 @@ type CompactorOptions struct {
 	// if a compaction must be scheduled
 	PollInterval time.Duration
 
+	// Timeout is the time compaction should wait before timing out network
+	// operations
+	Timeout time.Duration
+
 	// A compacted SSTable's maximum size (in bytes). If more data needs to be
 	// written to a Sorted Run during a compaction, a new SSTable will be created
 	// in the Sorted Run when this size is exceeded.
@@ -143,6 +147,8 @@ type CompactorOptions struct {
 func DefaultCompactorOptions() *CompactorOptions {
 	return &CompactorOptions{
 		PollInterval: 5 * time.Second,
-		MaxSSTSize:   1024 * 1024 * 1024,
+		// Ideally the timeout should be less than or equal to the poll interval.
+		Timeout:    5 * time.Second,
+		MaxSSTSize: 1024 * 1024 * 1024,
 	}
 }


### PR DESCRIPTION
### Purpose
All public methods which make network calls or await on flush should accept a `context.Context` which allows the caller to cancel the call if needed.

### Implementation
- Added `context.Context` to `Put()`
- Added `context.Context` to `PutWithOptions()` 
- Added `context.Context` to `Close()` 
- Added `context.Context` to `FlushWAL()`
- Added `context.Context` to `TableStore` methods
- Modified the `ReadOnlyBlob` interface to accept `context.Context`

NOTE: Adding context to Close allows the caller to add a timeout to how long the caller is willing to wait for the database to flush all it's buffers and close the database safely. 