### PR TITLE
Avoid using key/value in 'Put' signatures

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -34,12 +34,12 @@ func NextEntry(t *testing.T, iter iter.KVIterator, key []byte, value []byte) {
 // Next is a test helper to assert the next call to Next() returns the required value
 func Next(t *testing.T, iter iter.KVIterator, key []byte, value []byte) bool {
 	t.Helper()
-	kv, _ := iter.Next(context.Background())
+	e, _ := iter.NextEntry(context.Background())
 	//assert.True(t, ok)
-	if !assert2.Equal(t, key, kv.Key) {
+	if !assert2.Equal(t, key, e.Key) {
 		return false
 	}
-	if !assert2.Equal(t, value, kv.Value) {
+	if !assert2.Equal(t, value, e.Value.Value) {
 		return false
 	}
 	return true

--- a/internal/iter/entry.go
+++ b/internal/iter/entry.go
@@ -7,9 +7,6 @@ import (
 )
 
 type KVIterator interface {
-	// Next Returns the next non-deleted key-value pair in the iterator.
-	Next(context.Context) (types.KeyValue, bool)
-
 	// NextEntry Returns the next entry in the iterator, which may be a key-value pair or
 	// a tombstone of a deleted key-value pair.
 	NextEntry(context.Context) (types.RowEntry, bool)
@@ -30,17 +27,6 @@ func NewEntryIterator(entries ...types.RowEntry) *EntryIterator {
 		entries: entries,
 		index:   0,
 	}
-}
-
-func (k *EntryIterator) Next(ctx context.Context) (types.KeyValue, bool) {
-	for k.index < len(k.entries) {
-		entry := k.entries[k.index]
-		k.index++
-		if !entry.Value.IsTombstone() {
-			return types.KeyValue{Key: entry.Key, Value: entry.Value.Value}, true
-		}
-	}
-	return types.KeyValue{}, false
 }
 
 func (k *EntryIterator) NextEntry(ctx context.Context) (types.RowEntry, bool) {

--- a/internal/iter/merge.go
+++ b/internal/iter/merge.go
@@ -48,18 +48,6 @@ func NewMergeSort(ctx context.Context, iterators ...KVIterator) *MergeSort {
 	return ms
 }
 
-func (m *MergeSort) Next(ctx context.Context) (types.KeyValue, bool) {
-	for {
-		entry, ok := m.NextEntry(ctx)
-		if !ok {
-			return types.KeyValue{}, false
-		}
-		if !entry.Value.IsTombstone() {
-			return types.KeyValue{Key: entry.Key, Value: entry.Value.Value}, true
-		}
-	}
-}
-
 // NextEntry Returns the next entry in the iterator, which may be a key-value pair or
 // a tombstone of a deleted key-value pair.
 func (m *MergeSort) NextEntry(ctx context.Context) (types.RowEntry, bool) {

--- a/internal/iter/merge_test.go
+++ b/internal/iter/merge_test.go
@@ -32,7 +32,7 @@ func TestMergeUniqueIteratorPrecedence(t *testing.T) {
 	assert2.NextEntry(t, mergeIter, []byte("cccc"), []byte("use this one c"))
 	assert2.NextEntry(t, mergeIter, []byte("xxxx"), []byte("use this one x"))
 
-	_, ok := mergeIter.Next(context.Background())
+	_, ok := mergeIter.NextEntry(context.Background())
 	assert.False(t, ok, "Expected no more entries")
 }
 
@@ -65,7 +65,7 @@ func TestMergeUnique(t *testing.T) {
 	assert2.NextEntry(t, mergeIter, []byte("yyyy"), []byte("25252525"))
 	assert2.NextEntry(t, mergeIter, []byte("zzzz"), []byte("26262626"))
 
-	_, ok := mergeIter.Next(context.Background())
+	_, ok := mergeIter.NextEntry(context.Background())
 	assert.False(t, ok, "Expected no more entries")
 }
 
@@ -88,7 +88,7 @@ func TestMergeSortTwoIterators(t *testing.T) {
 	assert2.NextEntry(t, mergeIter, []byte("yyyy"), []byte("25252525"))
 	assert2.NextEntry(t, mergeIter, []byte("zzzz"), []byte("26262626"))
 
-	_, ok := mergeIter.Next(context.Background())
+	_, ok := mergeIter.NextEntry(context.Background())
 	assert.False(t, ok, "Expected no more entries")
 }
 
@@ -106,6 +106,6 @@ func TestMergeSortTwoIteratorsPrecedence(t *testing.T) {
 	assert2.NextEntry(t, mergeIter, []byte("cccc"), []byte("use this one c"))
 	assert2.NextEntry(t, mergeIter, []byte("xxxx"), []byte("24242424"))
 
-	_, ok := mergeIter.Next(context.Background())
+	_, ok := mergeIter.NextEntry(context.Background())
 	assert.False(t, ok, "Expected no more entries")
 }

--- a/internal/sstable/block/block_test.go
+++ b/internal/sstable/block/block_test.go
@@ -89,7 +89,6 @@ func TestSmallestCompressedBlock(t *testing.T) {
 		it := block.NewIterator(&decoded)
 		assert2.NextEntry(t, it, []byte("k"), nil)
 	}
-
 }
 
 func TestBlockWithTombstone(t *testing.T) {
@@ -160,15 +159,15 @@ func TestNewIteratorAtKey(t *testing.T) {
 
 		// Verify that iterator starts from index 1 which contains key "kratos"
 		for i := 1; i < len(kvPairs); i++ {
-			kv, ok := iter.Next(context.Background())
+			e, ok := iter.NextEntry(context.Background())
 			assert.True(t, ok)
-			assert.True(t, bytes.Equal(kv.Key, kvPairs[i].Key))
-			assert.True(t, bytes.Equal(kv.Value, kvPairs[i].Value))
+			assert.True(t, bytes.Equal(e.Key, kvPairs[i].Key))
+			assert.True(t, bytes.Equal(e.Value.Value, kvPairs[i].Value))
 		}
 
-		kv, ok := iter.Next(context.Background())
+		e, ok := iter.NextEntry(context.Background())
 		assert.False(t, ok)
-		assert.Equal(t, types.KeyValue{}, kv)
+		assert.Equal(t, types.RowEntry{}, e)
 	})
 
 	t.Run("FirstKey", func(t *testing.T) {
@@ -177,15 +176,15 @@ func TestNewIteratorAtKey(t *testing.T) {
 
 		// Verify that iterator starts from index 0 which contains key "donkey"
 		for i := 0; i < len(kvPairs); i++ {
-			kv, ok := iter.Next(context.Background())
+			e, ok := iter.NextEntry(context.Background())
 			assert.True(t, ok)
-			assert.True(t, bytes.Equal(kv.Key, kvPairs[i].Key))
-			assert.True(t, bytes.Equal(kv.Value, kvPairs[i].Value))
+			assert.True(t, bytes.Equal(e.Key, kvPairs[i].Key))
+			assert.True(t, bytes.Equal(e.Value.Value, kvPairs[i].Value))
 		}
 
-		kv, ok := iter.Next(context.Background())
+		e, ok := iter.NextEntry(context.Background())
 		assert.False(t, ok)
-		assert.Equal(t, types.KeyValue{}, kv)
+		assert.Equal(t, types.RowEntry{}, e)
 	})
 }
 
@@ -240,9 +239,9 @@ func TestIterFromEnd(t *testing.T) {
 	iter, err := block.NewIteratorAtKey(b, []byte("zzz"))
 	require.NoError(t, err)
 	// Verify that iterator starts from index 1 which contains key "kratos"
-	kv, ok := iter.Next(context.Background())
+	e, ok := iter.NextEntry(context.Background())
 	assert.False(t, ok)
-	assert.Equal(t, types.KeyValue{}, kv)
+	assert.Equal(t, types.RowEntry{}, e)
 }
 
 func TestNewBuilderWithOffsets(t *testing.T) {
@@ -520,7 +519,7 @@ func TestNewIteratorAtKeyWithCorruptedKeys(t *testing.T) {
 		// The iterator should start from the fourth key
 		assert2.Next(t, iter, []byte("key4"), []byte("value4"))
 		assert2.Next(t, iter, []byte("key5"), []byte("value5"))
-		_, ok := iter.Next(context.Background())
+		_, ok := iter.NextEntry(context.Background())
 		assert.False(t, ok)
 		assert.False(t, iter.Warnings().Empty())
 		//t.Logf("Warnings: %s", iter.Warnings())

--- a/internal/sstable/block/iterator.go
+++ b/internal/sstable/block/iterator.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/slatedb/slatedb-go/internal"
 	"sort"
 
+	"github.com/slatedb/slatedb-go/internal"
 	"github.com/slatedb/slatedb-go/internal/types"
 )
 
-// Iterator iterates through KeyValue pairs present in the Block.
+// Iterator iterates through KeyValues present in the Block.
 type Iterator struct {
 	block       *Block
 	offsetIndex uint64
@@ -79,22 +79,6 @@ func NewIteratorAtKey(block *Block, key []byte) (*Iterator, error) {
 		block:       block,
 		warn:        warn,
 	}, nil
-}
-
-func (iter *Iterator) Next(ctx context.Context) (types.KeyValue, bool) {
-	for {
-		entry, ok := iter.NextEntry(ctx)
-		if !ok {
-			return types.KeyValue{}, false
-		}
-		if entry.Value.IsTombstone() {
-			continue
-		}
-		return types.KeyValue{
-			Key:   entry.Key,
-			Value: entry.Value.Value,
-		}, true
-	}
 }
 
 func (iter *Iterator) NextEntry(ctx context.Context) (types.RowEntry, bool) {

--- a/internal/sstable/iterator.go
+++ b/internal/sstable/iterator.go
@@ -56,24 +56,6 @@ func NewIteratorAtKey(ctx context.Context, handle *Handle, key []byte, store Tab
 	return iter, nil
 }
 
-func (iter *Iterator) Next(ctx context.Context) (types.KeyValue, bool) {
-	for {
-		keyVal, ok := iter.NextEntry(ctx)
-		if !ok {
-			return types.KeyValue{}, false
-		}
-
-		if keyVal.Value.IsTombstone() {
-			continue
-		}
-
-		return types.KeyValue{
-			Key:   keyVal.Key,
-			Value: keyVal.Value.Value,
-		}, true
-	}
-}
-
 func (iter *Iterator) NextEntry(ctx context.Context) (types.RowEntry, bool) {
 	for {
 		if iter.blockIter == nil {

--- a/internal/sstable/sstable.go
+++ b/internal/sstable/sstable.go
@@ -8,7 +8,7 @@ import (
 
 // Info contains meta information on the SSTable when it is serialized.
 // This is used when we read SSTable as a slice of bytes from object storage and we want to parse the slice of bytes
-// Each SSTable is a list of blocks and each block is a list of KeyValue pairs.
+// Each SSTable is a list of blocks and each block is a list of KeyValues
 type Info struct {
 	// contains the FirstKey of the SSTable
 	FirstKey []byte

--- a/slatedb/compacted/sortedrun.go
+++ b/slatedb/compacted/sortedrun.go
@@ -110,23 +110,6 @@ func newSortedRunIter(ctx context.Context,
 	}, nil
 }
 
-func (iter *SortedRunIterator) Next(ctx context.Context) (types.KeyValue, bool) {
-	for {
-		keyVal, ok := iter.NextEntry(ctx)
-		if !ok {
-			return types.KeyValue{}, false
-		}
-		if keyVal.Value.IsTombstone() {
-			continue
-		}
-
-		return types.KeyValue{
-			Key:   keyVal.Key,
-			Value: keyVal.Value.Value,
-		}, true
-	}
-}
-
 func (iter *SortedRunIterator) NextEntry(ctx context.Context) (types.RowEntry, bool) {
 	for {
 		if iter.currentKVIter.IsAbsent() {

--- a/slatedb/compaction_test.go
+++ b/slatedb/compaction_test.go
@@ -62,21 +62,21 @@ func TestCompactorCompactsL0(t *testing.T) {
 	iter, err := sstable.NewIterator(ctx, &sst, tableStore)
 	assert.NoError(t, err)
 	for i := 0; i < 4; i++ {
-		kv, ok := iter.Next(context.Background())
+		e, ok := iter.NextEntry(context.Background())
 		assert.True(t, ok)
-		assert.Equal(t, repeatedChar(rune('a'+i), 16), kv.Key)
-		assert.Equal(t, repeatedChar(rune('b'+i), 48), kv.Value)
+		assert.Equal(t, repeatedChar(rune('a'+i), 16), e.Key)
+		assert.Equal(t, repeatedChar(rune('b'+i), 48), e.Value.Value)
 	}
 	for i := 0; i < 4; i++ {
-		kv, ok := iter.Next(context.Background())
+		e, ok := iter.NextEntry(context.Background())
 		assert.True(t, ok)
-		assert.Equal(t, repeatedChar(rune('j'+i), 16), kv.Key)
-		assert.Equal(t, repeatedChar(rune('k'+i), 48), kv.Value)
+		assert.Equal(t, repeatedChar(rune('j'+i), 16), e.Key)
+		assert.Equal(t, repeatedChar(rune('k'+i), 48), e.Value.Value)
 	}
 
-	next, ok := iter.Next(context.Background())
+	next, ok := iter.NextEntry(context.Background())
 	assert.False(t, ok)
-	assert.Equal(t, types.KeyValue{}, next)
+	assert.Equal(t, types.RowEntry{}, next)
 }
 
 func TestShouldWriteManifestSafely(t *testing.T) {

--- a/slatedb/flush.go
+++ b/slatedb/flush.go
@@ -86,12 +86,8 @@ func (db *DB) flushImmWALToMemtable(immWal *table.ImmutableWAL, memtable *table.
 		if err != nil || entry.IsAbsent() {
 			break
 		}
-		kv, _ := entry.Get()
-		if kv.Value.IsTombstone() {
-			memtable.Delete(kv.Key)
-		} else {
-			memtable.Put(kv.Key, kv.Value.Value)
-		}
+		e, _ := entry.Get()
+		memtable.Put(e)
 	}
 	memtable.SetLastWalID(immWal.ID())
 }

--- a/slatedb/sortedrun_test.go
+++ b/slatedb/sortedrun_test.go
@@ -68,9 +68,9 @@ func TestOneSstSRIter(t *testing.T) {
 	assert2.Next(t, iterator, []byte("key2"), []byte("value2"))
 	assert2.Next(t, iterator, []byte("key3"), []byte("value3"))
 
-	kv, ok := iterator.Next(context.Background())
+	next, ok := iterator.NextEntry(context.Background())
 	assert.False(t, ok)
-	assert.Equal(t, types.KeyValue{}, kv)
+	assert.Equal(t, types.RowEntry{}, next)
 }
 
 func TestManySstSRIter(t *testing.T) {
@@ -107,9 +107,9 @@ func TestManySstSRIter(t *testing.T) {
 	assert2.Next(t, iterator, []byte("key2"), []byte("value2"))
 	assert2.Next(t, iterator, []byte("key3"), []byte("value3"))
 
-	kv, ok := iterator.Next(context.Background())
+	next, ok := iterator.NextEntry(context.Background())
 	assert.False(t, ok)
-	assert.Equal(t, types.KeyValue{}, kv)
+	assert.Equal(t, types.RowEntry{}, next)
 }
 
 func TestSRIterFromKey(t *testing.T) {
@@ -143,9 +143,9 @@ func TestSRIterFromKey(t *testing.T) {
 		for j := 0; j < 30-i; j++ {
 			assert2.Next(t, kvIter, expectedKeyGen.Next(), expectedValGen.Next())
 		}
-		next, ok := kvIter.Next(context.Background())
+		next, ok := kvIter.NextEntry(context.Background())
 		assert.False(t, ok)
-		assert.Equal(t, types.KeyValue{}, next)
+		assert.Equal(t, types.RowEntry{}, next)
 	}
 }
 
@@ -175,9 +175,9 @@ func TestSRIterFromKeyLowerThanRange(t *testing.T) {
 	for j := 0; j < 30; j++ {
 		assert2.Next(t, kvIter, expectedKeyGen.Next(), expectedValGen.Next())
 	}
-	next, ok := kvIter.Next(context.Background())
+	next, ok := kvIter.NextEntry(context.Background())
 	assert.False(t, ok)
-	assert.Equal(t, types.KeyValue{}, next)
+	assert.Equal(t, types.RowEntry{}, next)
 }
 
 func TestSRIterFromKeyHigherThanRange(t *testing.T) {
@@ -199,7 +199,7 @@ func TestSRIterFromKeyHigherThanRange(t *testing.T) {
 
 	kvIter, err := compacted.NewSortedRunIteratorFromKey(ctx, sr, []byte("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"), tableStore)
 	assert.NoError(t, err)
-	next, ok := kvIter.Next(context.Background())
+	next, ok := kvIter.NextEntry(context.Background())
 	assert.False(t, ok)
-	assert.Equal(t, types.KeyValue{}, next)
+	assert.Equal(t, types.RowEntry{}, next)
 }

--- a/slatedb/state/db_state.go
+++ b/slatedb/state/db_state.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"github.com/slatedb/slatedb-go/internal/types"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -180,30 +181,18 @@ func (s *DBState) LastCompactedWALID() uint64 {
 	return s.core.lastCompactedWalSSTID.Load()
 }
 
-func (s *DBState) PutKVToWAL(key []byte, value []byte) *table.WAL {
+func (s *DBState) WalPut(entry types.RowEntry) *table.WAL {
 	s.Lock()
 	defer s.Unlock()
-	s.wal.Put(key, value)
+	s.wal.Put(entry)
 	return s.wal
 }
 
-func (s *DBState) DeleteKVFromWAL(key []byte) *table.WAL {
+func (s *DBState) MemTablePut(entry types.RowEntry) *table.Memtable {
 	s.Lock()
 	defer s.Unlock()
-	s.wal.Delete(key)
-	return s.wal
-}
-
-func (s *DBState) PutKVToMemtable(key []byte, value []byte) {
-	s.Lock()
-	defer s.Unlock()
-	s.memtable.Put(key, value)
-}
-
-func (s *DBState) DeleteKVFromMemtable(key []byte) {
-	s.Lock()
-	defer s.Unlock()
-	s.memtable.Delete(key)
+	s.memtable.Put(entry)
+	return s.memtable
 }
 
 func (s *DBState) CoreStateSnapshot() *CoreStateSnapshot {

--- a/slatedb/store/table_store_test.go
+++ b/slatedb/store/table_store_test.go
@@ -378,7 +378,7 @@ func TestOneBlockSSTIter(t *testing.T) {
 	assert2.Next(t, iterator, []byte("key3"), []byte("value3"))
 	assert2.Next(t, iterator, []byte("key4"), []byte("value4"))
 
-	_, ok := iterator.Next(context.Background())
+	_, ok := iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 }
 
@@ -416,7 +416,7 @@ func TestManyBlockSSTIter(t *testing.T) {
 		}
 	}
 
-	_, ok := iterator.Next(context.Background())
+	_, ok := iterator.NextEntry(context.Background())
 	assert.False(t, ok)
 }
 
@@ -451,7 +451,7 @@ func TestIterFromKey(t *testing.T) {
 				t.FailNow()
 			}
 		}
-		_, ok := kvIter.Next(context.Background())
+		_, ok := kvIter.NextEntry(context.Background())
 		assert.False(t, ok)
 	}
 }
@@ -480,7 +480,7 @@ func TestIterFromKeySmallerThanFirst(t *testing.T) {
 	for i := 0; i < nKeys; i++ {
 		assert2.Next(t, kvIter, expectedKeyGen.Next(), expectedValGen.Next())
 	}
-	_, ok := kvIter.Next(context.Background())
+	_, ok := kvIter.NextEntry(context.Background())
 	assert.False(t, ok)
 }
 
@@ -502,7 +502,7 @@ func TestIterFromKeyLargerThanLast(t *testing.T) {
 	kvIter, err := sstable.NewIteratorAtKey(ctx, sst, []byte("zzzzzzzzzzzzzzzz"), tableStore)
 	assert.NoError(t, err)
 
-	_, ok := kvIter.Next(context.Background())
+	_, ok := kvIter.NextEntry(context.Background())
 	assert.False(t, ok)
 }
 

--- a/slatedb/table/memtable.go
+++ b/slatedb/table/memtable.go
@@ -27,23 +27,17 @@ func NewMemtable() *Memtable {
 	}
 }
 
-// Put adds KeyValue and returns the size in bytes of the KeyValue added
-func (m *Memtable) Put(key []byte, value []byte) int64 {
+// Put adds RowEntry and returns the size in bytes of the RowEntry added
+func (m *Memtable) Put(entry types.RowEntry) int64 {
 	m.Lock()
 	defer m.Unlock()
-	return m.table.put(key, value)
+	return m.table.put(entry)
 }
 
 func (m *Memtable) Get(key []byte) mo.Option[types.Value] {
 	m.RLock()
 	defer m.RUnlock()
 	return m.table.get(key)
-}
-
-func (m *Memtable) Delete(key []byte) {
-	m.Lock()
-	defer m.Unlock()
-	m.table.delete(key)
 }
 
 func (m *Memtable) Size() int64 {

--- a/slatedb/table/memtable_test.go
+++ b/slatedb/table/memtable_test.go
@@ -10,40 +10,45 @@ import (
 )
 
 func TestMemtableOps(t *testing.T) {
-	kvPairs := []types.KeyValue{
-		{Key: []byte("abc111"), Value: []byte("value1")},
-		{Key: []byte("abc222"), Value: []byte("value2")},
-		{Key: []byte("abc333"), Value: []byte("value3")},
+	entries := []types.RowEntry{
+		{Key: []byte("abc111"), Value: types.Value{Value: []byte("value1"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc222"), Value: types.Value{Value: []byte("value2"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}},
 	}
 
 	memtable := NewMemtable()
 
 	var size int64
-	// Put KeyValue pairs
-	for _, kvPair := range kvPairs {
-		size += memtable.Put(kvPair.Key, kvPair.Value)
+	// Put entries
+	for _, e := range entries {
+		size += memtable.Put(e)
 	}
-	// verify Get for all the KeyValue pairs
-	for _, kvPair := range kvPairs {
-		assert.Equal(t, kvPair.Value, memtable.Get(kvPair.Key).MustGet().Value)
+	// verify Get for all the entries
+	for _, e := range entries {
+		assert.Equal(t, e.Value.Value, memtable.Get(e.Key).MustGet().Value)
 	}
 	assert.Equal(t, size, memtable.Size())
 
-	// Delete KeyValue and verify that it is tombstoned
-	memtable.Delete(kvPairs[1].Key)
-	assert.True(t, memtable.Get(kvPairs[1].Key).MustGet().IsTombstone())
+	// Delete and verify that it is tombstoned
+	memtable.Put(types.RowEntry{
+		Key: entries[1].Key,
+		Value: types.Value{
+			Kind: types.KindTombStone,
+		},
+	})
+	assert.True(t, memtable.Get(entries[1].Key).MustGet().IsTombstone())
 
 	memtable.SetLastWalID(1)
 	assert.Equal(t, uint64(1), memtable.LastWalID().MustGet())
 }
 
 func TestMemtableIter(t *testing.T) {
-	kvPairs := []types.KeyValue{
-		{Key: []byte("abc111"), Value: []byte("value1")},
-		{Key: []byte("abc222"), Value: []byte("value2")},
-		{Key: []byte("abc333"), Value: []byte("value3")},
-		{Key: []byte("abc444"), Value: []byte("value4")},
-		{Key: []byte("abc555"), Value: []byte("value5")},
+	entries := []types.RowEntry{
+		{Key: []byte("abc111"), Value: types.Value{Value: []byte("value1"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc222"), Value: types.Value{Value: []byte("value2"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc444"), Value: types.Value{Value: []byte("value4"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc555"), Value: types.Value{Value: []byte("value5"), Kind: types.KindKeyValue}},
 	}
 
 	memtable := NewMemtable()
@@ -51,45 +56,49 @@ func TestMemtableIter(t *testing.T) {
 	// Put keys in random order
 	indexes := []int{2, 0, 4, 3, 1}
 	for i := range indexes {
-		memtable.Put(kvPairs[i].Key, kvPairs[i].Value)
+		memtable.Put(entries[i])
 	}
 
 	iter := memtable.Iter()
 
 	// Verify that iterator returns keys in sorted order
-	for i := 0; i < len(kvPairs); i++ {
-		next, err := iter.Next()
+	for i := 0; i < len(entries); i++ {
+		next, err := iter.NextEntry()
 		assert.NoError(t, err)
-		kv, ok := next.Get()
+		e, ok := next.Get()
 		assert.True(t, ok)
-		assert.Equal(t, kvPairs[i].Key, kv.Key)
-		assert.Equal(t, kvPairs[i].Value, kv.Value)
+		assert.Equal(t, entries[i].Key, e.Key)
+		assert.Equal(t, entries[i].Value.Value, e.Value.Value)
+		assert.Equal(t, entries[i].Value.Kind, e.Value.Kind)
 	}
 }
 
-func TestMemtableIterDelete(t *testing.T) {
+func TestMemtableIterTombstone(t *testing.T) {
 	memtable := NewMemtable()
 
 	// verify that iter.Next() is present after adding a key
-	memtable.Put([]byte("abc333"), []byte("value3"))
-	next, err := memtable.Iter().Next()
+	memtable.Put(types.RowEntry{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}})
+	next, err := memtable.Iter().NextEntry()
 	assert.NoError(t, err)
 	assert.True(t, next.IsPresent())
 
-	// verify that iter.Next() is absent after deleting a key and no other key present
-	memtable.Delete([]byte("abc333"))
-	next, err = memtable.Iter().Next()
+	// verify that iter.Next() returns tombstone after marking a key as deleted
+	memtable.Put(types.RowEntry{Key: []byte("abc333"), Value: types.Value{Kind: types.KindTombStone}})
+	next, err = memtable.Iter().NextEntry()
 	assert.NoError(t, err)
-	assert.False(t, next.IsPresent())
+	assert.True(t, next.IsPresent())
+	kv, ok := next.Get()
+	assert.True(t, ok)
+	assert.True(t, kv.Value.IsTombstone())
 }
 
 func TestMemtableRangeFromExistingKey(t *testing.T) {
-	kvPairs := []types.KeyValue{
-		{Key: []byte("abc111"), Value: []byte("value1")},
-		{Key: []byte("abc222"), Value: []byte("value2")},
-		{Key: []byte("abc333"), Value: []byte("value3")},
-		{Key: []byte("abc444"), Value: []byte("value4")},
-		{Key: []byte("abc555"), Value: []byte("value5")},
+	entries := []types.RowEntry{
+		{Key: []byte("abc111"), Value: types.Value{Value: []byte("value1"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc222"), Value: types.Value{Value: []byte("value2"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc444"), Value: types.Value{Value: []byte("value4"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc555"), Value: types.Value{Value: []byte("value5"), Kind: types.KindKeyValue}},
 	}
 
 	memtable := NewMemtable()
@@ -97,29 +106,30 @@ func TestMemtableRangeFromExistingKey(t *testing.T) {
 	// Put keys in random order
 	indexes := []int{2, 0, 4, 3, 1}
 	for i := range indexes {
-		memtable.Put(kvPairs[i].Key, kvPairs[i].Value)
+		memtable.Put(entries[indexes[i]])
 	}
 
 	iter := memtable.RangeFrom([]byte("abc333"))
 
 	// Verify that iterator starts from index 2 which contains key abc333
-	for i := 2; i < len(kvPairs); i++ {
-		next, err := iter.Next()
+	for i := 2; i < len(entries); i++ {
+		next, err := iter.NextEntry()
 		assert.NoError(t, err)
-		kv, ok := next.Get()
+		e, ok := next.Get()
 		assert.True(t, ok)
-		assert.Equal(t, kvPairs[i].Key, kv.Key)
-		assert.Equal(t, kvPairs[i].Value, kv.Value)
+		assert.Equal(t, entries[i].Key, e.Key)
+		assert.Equal(t, entries[i].Value.Value, e.Value.Value)
+		assert.Equal(t, entries[i].Value.Kind, e.Value.Kind)
 	}
 }
 
 func TestMemtableRangeFromNonExistingKey(t *testing.T) {
-	kvPairs := []types.KeyValue{
-		{Key: []byte("abc111"), Value: []byte("value1")},
-		{Key: []byte("abc222"), Value: []byte("value2")},
-		{Key: []byte("abc333"), Value: []byte("value3")},
-		{Key: []byte("abc444"), Value: []byte("value4")},
-		{Key: []byte("abc555"), Value: []byte("value5")},
+	entries := []types.RowEntry{
+		{Key: []byte("abc111"), Value: types.Value{Value: []byte("value1"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc222"), Value: types.Value{Value: []byte("value2"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc444"), Value: types.Value{Value: []byte("value4"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc555"), Value: types.Value{Value: []byte("value5"), Kind: types.KindKeyValue}},
 	}
 
 	memtable := NewMemtable()
@@ -127,67 +137,69 @@ func TestMemtableRangeFromNonExistingKey(t *testing.T) {
 	// Put keys in random order
 	indexes := []int{2, 0, 4, 3, 1}
 	for i := range indexes {
-		memtable.Put(kvPairs[i].Key, kvPairs[i].Value)
+		memtable.Put(entries[indexes[i]])
 	}
 
 	iter := memtable.RangeFrom([]byte("abc345"))
 
 	// Verify that iterator starts from index 3 which contains key abc444
-	for i := 3; i < len(kvPairs); i++ {
-		next, err := iter.Next()
+	for i := 3; i < len(entries); i++ {
+		next, err := iter.NextEntry()
 		assert.NoError(t, err)
-		kv, ok := next.Get()
+		e, ok := next.Get()
 		assert.True(t, ok)
-		assert.Equal(t, kvPairs[i].Key, kv.Key)
-		assert.Equal(t, kvPairs[i].Value, kv.Value)
+		assert.Equal(t, entries[i].Key, e.Key)
+		assert.Equal(t, entries[i].Value.Value, e.Value.Value)
+		assert.Equal(t, entries[i].Value.Kind, e.Value.Kind)
 	}
 }
 
 func TestImmMemtableOps(t *testing.T) {
-	kvPairs := []types.KeyValue{
-		{Key: []byte("abc111"), Value: []byte("value1")},
-		{Key: []byte("abc222"), Value: []byte("value2")},
-		{Key: []byte("abc333"), Value: []byte("value3")},
+	entries := []types.RowEntry{
+		{Key: []byte("abc111"), Value: types.Value{Value: []byte("value1"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc222"), Value: types.Value{Value: []byte("value2"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}},
 	}
 
 	memtable := NewMemtable()
 	// Put keys in random order
 	indexes := []int{1, 2, 0}
 	for i := range indexes {
-		memtable.Put(kvPairs[i].Key, kvPairs[i].Value)
+		memtable.Put(entries[indexes[i]])
 	}
 
-	// create ImmutableMemtable from memtable and verify Get values for all KeyValue pairs
+	// create ImmutableMemtable from memtable and verify Get values for all entries
 	immMemtable := NewImmutableMemtable(memtable, 1)
-	for _, kvPair := range kvPairs {
-		assert.Equal(t, kvPair.Value, immMemtable.Get(kvPair.Key).MustGet().Value)
+	for _, entry := range entries {
+		assert.Equal(t, entry.Value.Value, immMemtable.Get(entry.Key).MustGet().Value)
 	}
 	assert.Equal(t, uint64(1), immMemtable.LastWalID())
 
 	iter := immMemtable.Iter()
 
 	// Verify that iterator returns keys in sorted order
-	for i := 0; i < len(kvPairs); i++ {
-		next, err := iter.Next()
+	for i := 0; i < len(entries); i++ {
+		next, err := iter.NextEntry()
 		assert.NoError(t, err)
-		kv, ok := next.Get()
+		e, ok := next.Get()
 		assert.True(t, ok)
-		assert.Equal(t, kvPairs[i].Key, kv.Key)
-		assert.Equal(t, kvPairs[i].Value, kv.Value)
+		assert.Equal(t, entries[i].Key, e.Key)
+		assert.Equal(t, entries[i].Value.Value, e.Value.Value)
+		assert.Equal(t, entries[i].Value.Kind, e.Value.Kind)
 	}
 }
 
 func TestMemtableClone(t *testing.T) {
-	kvPairs := []types.KeyValue{
-		{Key: []byte("abc111"), Value: []byte("value1")},
-		{Key: []byte("abc222"), Value: []byte("value2")},
-		{Key: []byte("abc333"), Value: []byte("value3")},
+	entries := []types.RowEntry{
+		{Key: []byte("abc111"), Value: types.Value{Value: []byte("value1"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc222"), Value: types.Value{Value: []byte("value2"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}},
 	}
 
 	memtable := NewMemtable()
-	// Put KeyValue pairs to memtable
-	for _, kvPair := range kvPairs {
-		memtable.Put(kvPair.Key, kvPair.Value)
+	// Put RowEntry pairs to memtable
+	for _, entry := range entries {
+		memtable.Put(entry)
 	}
 	memtable.SetLastWalID(1)
 
@@ -198,10 +210,10 @@ func TestMemtableClone(t *testing.T) {
 
 	// verify that the clone does not point to same data in memory
 	key := []byte("abc333")
-	newValue := []byte("newValue")
-	memtable.Put(key, newValue)
-	assert.Equal(t, newValue, memtable.Get(key).MustGet().Value)
-	assert.NotEqual(t, newValue, clonedMemtable.Get(key).MustGet().Value)
+	newValue := types.Value{Value: []byte("newValue"), Kind: types.KindKeyValue}
+	memtable.Put(types.RowEntry{Key: key, Value: newValue})
+	assert.Equal(t, newValue.Value, memtable.Get(key).MustGet().Value)
+	assert.NotEqual(t, newValue.Value, clonedMemtable.Get(key).MustGet().Value)
 
 	immMemtable := NewImmutableMemtable(memtable, 1)
 	clonedImmMemtable := immMemtable.Clone()

--- a/slatedb/table/wal.go
+++ b/slatedb/table/wal.go
@@ -23,22 +23,16 @@ func NewWAL() *WAL {
 	}
 }
 
-func (w *WAL) Put(key []byte, value []byte) int64 {
+func (w *WAL) Put(entry types.RowEntry) int64 {
 	w.Lock()
 	defer w.Unlock()
-	return w.table.put(key, value)
+	return w.table.put(entry)
 }
 
 func (w *WAL) Get(key []byte) mo.Option[types.Value] {
 	w.RLock()
 	defer w.RUnlock()
 	return w.table.get(key)
-}
-
-func (w *WAL) Delete(key []byte) {
-	w.Lock()
-	defer w.Unlock()
-	w.table.delete(key)
 }
 
 func (w *WAL) Table() *KVTable {

--- a/slatedb/table/wal_test.go
+++ b/slatedb/table/wal_test.go
@@ -4,127 +4,131 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/slatedb/slatedb-go/internal/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWALOps(t *testing.T) {
-	kvPairs := []types.KeyValue{
-		{Key: []byte("abc111"), Value: []byte("value1")},
-		{Key: []byte("abc222"), Value: []byte("value2")},
-		{Key: []byte("abc333"), Value: []byte("value3")},
+	kvPairs := []types.RowEntry{
+		{Key: []byte("abc111"), Value: types.Value{Value: []byte("value1"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc222"), Value: types.Value{Value: []byte("value2"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}},
 	}
 
 	wal := NewWAL()
 	assert.Equal(t, int64(0), wal.Size())
 
 	var size int64
-	// Put KeyValue pairs
-	for _, kvPair := range kvPairs {
-		size += wal.Put(kvPair.Key, kvPair.Value)
+	// Put RowEntry pairs
+	for _, entry := range kvPairs {
+		size += wal.Put(entry)
 	}
-	// verify Get values for all KeyValue pairs
-	for _, kvPair := range kvPairs {
-		assert.Equal(t, kvPair.Value, wal.Get(kvPair.Key).MustGet().Value)
+	// verify Get values for all RowEntry pairs
+	for _, entry := range kvPairs {
+		assert.Equal(t, entry.Value, wal.Get(entry.Key).MustGet())
 	}
 	assert.Equal(t, size, wal.Size())
 
-	// Delete KeyValue and verify that it is tombstoned
-	wal.Delete(kvPairs[1].Key)
+	// Put a tombstone and verify that it is tombstoned
+	wal.Put(types.RowEntry{Key: kvPairs[1].Key, Value: types.Value{Kind: types.KindTombStone}})
 	assert.True(t, wal.Get(kvPairs[1].Key).MustGet().IsTombstone())
 }
 
 func TestWALIter(t *testing.T) {
-	kvPairs := []types.KeyValue{
-		{Key: []byte("abc111"), Value: []byte("value1")},
-		{Key: []byte("abc222"), Value: []byte("value2")},
-		{Key: []byte("abc333"), Value: []byte("value3")},
-		{Key: []byte("abc444"), Value: []byte("value4")},
-		{Key: []byte("abc555"), Value: []byte("value5")},
+	entries := []types.RowEntry{
+		{Key: []byte("abc111"), Value: types.Value{Value: []byte("value1"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc222"), Value: types.Value{Value: []byte("value2"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc444"), Value: types.Value{Value: []byte("value4"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc555"), Value: types.Value{Value: []byte("value5"), Kind: types.KindKeyValue}},
 	}
 
 	wal := NewWAL()
 
-	// Put keys in random order
+	// Put entries in random order
 	indexes := []int{2, 0, 4, 3, 1}
-	for i := range indexes {
-		wal.Put(kvPairs[i].Key, kvPairs[i].Value)
+	for _, i := range indexes {
+		wal.Put(entries[i])
 	}
 
 	iter := wal.Iter()
 
-	// Verify that iterator returns keys in sorted order
-	for i := 0; i < len(kvPairs); i++ {
-		next, err := iter.Next()
+	// Verify that iterator returns entries in sorted order
+	for i := 0; i < len(entries); i++ {
+		next, err := iter.NextEntry()
 		assert.NoError(t, err)
-		kv, ok := next.Get()
+		entry, ok := next.Get()
 		assert.True(t, ok)
-		assert.Equal(t, kvPairs[i].Key, kv.Key)
-		assert.Equal(t, kvPairs[i].Value, kv.Value)
+		assert.Equal(t, entries[i].Key, entry.Key)
+		assert.Equal(t, entries[i].Value.Value, entry.Value.Value)
+		assert.Equal(t, entries[i].Value.Kind, entry.Value.Kind)
 	}
 }
 
-func TestWALIterDelete(t *testing.T) {
+func TestWALIterTombstone(t *testing.T) {
 	wal := NewWAL()
 
 	// verify that iter.Next() is present after adding a key
-	wal.Put([]byte("abc333"), []byte("value3"))
-	next, err := wal.Iter().Next()
+	wal.Put(types.RowEntry{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}})
+	next, err := wal.Iter().NextEntry()
 	assert.NoError(t, err)
 	assert.True(t, next.IsPresent())
 
-	// verify that iter.Next() is absent after deleting a key and no other key present
-	wal.Delete([]byte("abc333"))
-	next, err = wal.Iter().Next()
+	// verify that iter.Next() returns a tombstone after putting a tombstone
+	wal.Put(types.RowEntry{Key: []byte("abc333"), Value: types.Value{Kind: types.KindTombStone}})
+	next, err = wal.Iter().NextEntry()
 	assert.NoError(t, err)
-	assert.False(t, next.IsPresent())
+	assert.True(t, next.IsPresent())
+	entry, ok := next.Get()
+	assert.True(t, ok)
+	assert.True(t, entry.Value.IsTombstone())
 }
 
 func TestImmWALOps(t *testing.T) {
-	kvPairs := []types.KeyValue{
-		{Key: []byte("abc111"), Value: []byte("value1")},
-		{Key: []byte("abc222"), Value: []byte("value2")},
-		{Key: []byte("abc333"), Value: []byte("value3")},
+	entries := []types.RowEntry{
+		{Key: []byte("abc111"), Value: types.Value{Value: []byte("value1"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc222"), Value: types.Value{Value: []byte("value2"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}},
 	}
 
 	wal := NewWAL()
-	// Put KeyValue pairs to wal
-	for _, kvPair := range kvPairs {
-		wal.Put(kvPair.Key, kvPair.Value)
+	// Put RowEntry pairs to wal
+	for _, entry := range entries {
+		wal.Put(entry)
 	}
 
-	// create ImmutableMemtable from memtable and verify Get values for all KeyValue pairs
+	// create ImmutableWAL from WAL and verify Get values for all RowEntry pairs
 	immWAL := NewImmutableWAL(wal, 1)
-	for _, kvPair := range kvPairs {
-		assert.Equal(t, kvPair.Value, immWAL.Get(kvPair.Key).MustGet().Value)
+	for _, entry := range entries {
+		assert.Equal(t, entry.Value, immWAL.Get(entry.Key).MustGet())
 	}
 	assert.Equal(t, uint64(1), immWAL.ID())
 
 	iter := immWAL.Iter()
 
-	// Verify that iterator returns keys in sorted order
-	for i := 0; i < len(kvPairs); i++ {
-		next, err := iter.Next()
+	// Verify that iterator returns entries in sorted order
+	for i := 0; i < len(entries); i++ {
+		next, err := iter.NextEntry()
 		assert.NoError(t, err)
-		kv, ok := next.Get()
+		entry, ok := next.Get()
 		assert.True(t, ok)
-		assert.Equal(t, kvPairs[i].Key, kv.Key)
-		assert.Equal(t, kvPairs[i].Value, kv.Value)
+		assert.Equal(t, entries[i].Key, entry.Key)
+		assert.Equal(t, entries[i].Value.Value, entry.Value.Value)
+		assert.Equal(t, entries[i].Value.Kind, entry.Value.Kind)
 	}
 }
 
 func TestWALClone(t *testing.T) {
-	kvPairs := []types.KeyValue{
-		{Key: []byte("abc111"), Value: []byte("value1")},
-		{Key: []byte("abc222"), Value: []byte("value2")},
-		{Key: []byte("abc333"), Value: []byte("value3")},
+	entries := []types.RowEntry{
+		{Key: []byte("abc111"), Value: types.Value{Value: []byte("value1"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc222"), Value: types.Value{Value: []byte("value2"), Kind: types.KindKeyValue}},
+		{Key: []byte("abc333"), Value: types.Value{Value: []byte("value3"), Kind: types.KindKeyValue}},
 	}
 
 	wal := NewWAL()
-	// Put KeyValue pairs to wal
-	for _, kvPair := range kvPairs {
-		wal.Put(kvPair.Key, kvPair.Value)
+	// Put RowEntry pairs to wal
+	for _, entry := range entries {
+		wal.Put(entry)
 	}
 
 	clonedWAL := wal.Clone()
@@ -133,10 +137,10 @@ func TestWALClone(t *testing.T) {
 
 	// verify that the clone does not point to same data in memory
 	key := []byte("abc333")
-	newValue := []byte("newValue")
-	wal.Put(key, newValue)
-	assert.Equal(t, newValue, wal.Get(key).MustGet().Value)
-	assert.NotEqual(t, newValue, clonedWAL.Get(key).MustGet().Value)
+	newValue := types.Value{Value: []byte("newValue"), Kind: types.KindKeyValue}
+	wal.Put(types.RowEntry{Key: key, Value: newValue})
+	assert.Equal(t, newValue, wal.Get(key).MustGet())
+	assert.NotEqual(t, newValue, clonedWAL.Get(key).MustGet())
 
 	immWAL := NewImmutableWAL(wal, 1)
 	clonedImmWAL := immWAL.Clone()


### PR DESCRIPTION
### Purpose
In prep for eventual Merge Operator support we should avoid using key/value in `Put` signatures and prefer to pass along the `types.RowEntry` as they are provided to us by `DB.Put()` and `DB.Delete()`

This also simplifies moving entries from the `WAL` to the `MemTable`.
### Implementation
- Changed the signature of `WAL.Put` and `Memtable.Put`
- Changed the name of `PutKVToWAL` to `WalPut`
- Changed the name of `PutKVToMemtable` to `MemTablePut`
- Removed most `Delete` methods as calls to `Put` are now identical
	- Removed `Next()` from the `KVIterator` interface as implementations should act upon `types.RowEntry` and not individual key/values.
- Removed the following as they are no longer used
	- `KVTableIterator.Next`
	- `EntryIterator.Next`
	- `block/Iterator.Next`
	- `sstable/Iterator.Next`
	- `MergeSort.Next`
	- `SortedRunIterator.Next`

Now that there is no reason to differentiate between `Next()` and `NextEntry()` we may consider renaming `NextEntry()` to `Next()` at some point in the future. Doing that now might make this PR confusing.