### PR TITLE
Added DumpManifest() to aid in diagnostics

### DIFF
--- a/internal/sstable/dump.go
+++ b/internal/sstable/dump.go
@@ -8,7 +8,7 @@ import (
 	"github.com/slatedb/slatedb-go/internal/sstable/block"
 )
 
-// PrettyPrint returns a string representation of the SSTable in a human-readable format
+// Dump returns a string representation of the SSTable in a human-readable format
 //
 // SSTable Info:
 //
@@ -52,7 +52,7 @@ import (
 //	      Offset: 0
 //	          Key: []byte("key4") - 4 bytes
 //	        Value: []byte("value4") - 6 bytes
-func PrettyPrint(table *Table) string {
+func Dump(table *Table) string {
 	var buf bytes.Buffer
 
 	// Print SSTable Info

--- a/internal/sstable/dump_test.go
+++ b/internal/sstable/dump_test.go
@@ -3,12 +3,11 @@ package sstable
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/slatedb/slatedb-go/internal/compress"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestPrettyPrint(t *testing.T) {
+func TestDump(t *testing.T) {
 	conf := Config{
 		Compression:      compress.CodecNone,
 		BlockSize:        45,
@@ -29,7 +28,7 @@ func TestPrettyPrint(t *testing.T) {
 	table, err := builder.Build()
 	assert.NoError(t, err)
 
-	prettyOutput := PrettyPrint(table)
+	prettyOutput := Dump(table)
 	//t.Logf("%s", prettyOutput)
 
 	// Add some basic assertions

--- a/slatedb/state/db_state.go
+++ b/slatedb/state/db_state.go
@@ -107,6 +107,14 @@ func (c *CoreDBState) Snapshot() *CoreStateSnapshot {
 	return coreState
 }
 
+func (c *CoreDBState) NextWALID() uint64 {
+	return c.nextWalSstID.Load()
+}
+
+func (c *CoreDBState) LastCompactedWALID() uint64 {
+	return c.lastCompactedWalSSTID.Load()
+}
+
 func LogState(log *slog.Logger, c *CoreDBState) {
 	log.Info("DB Levels:")
 	log.Info("-----------------")


### PR DESCRIPTION
### Purpose
When diagnosing problems, it is useful for developers and operators to have the ability to inspect the contents of the manifest. 

### Implementation
- Added `slatedb.DumpManifest()`
- Renamed `PrettyPrint` to `sstable.Dump()` for consistency.